### PR TITLE
Add support for sending CloudTrail events to CloudWatch Logs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: trussworks/circleci-docker-primary:981d9ca384027eac96b787dc138a2d5144cf2527
+      - image: trussworks/circleci-docker-primary:a9f8bd446144cc09126bdb3905615c4e7dd6af80
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v1.3.0
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v1.3.0
     hooks:
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-yaml
-    -   id: detect-private-key
-    -   id: pretty-format-json
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: detect-private-key
+      - id: pretty-format-json
         args:
-        - --autofix
-    -   id: trailing-whitespace
+          - --autofix
+      - id: trailing-whitespace
 
--   repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: git://github.com/igorshubovych/markdownlint-cli
+    rev: v0.11.0
+    hooks:
+      - id: markdownlint
+
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
     rev: v1.7.3
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
       - id: terraform_validate_no_variables
-
--   repo: git://github.com/igorshubovych/markdownlint-cli
-    sha: v0.10.0
-    hooks:
-    -   id: markdownlint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Creates and configures an S3 bucket for storing logs from various AWS
 services and enables CloudTrail on all regions. Logs will expire after a
-default of 90 days.
+default of 90 days. Includes support for sending CloudTrail events to a
+CloudWatch Logs group.
 
 Logging from the following services is supported:
 
@@ -25,6 +26,7 @@ Logging from the following services is supported:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_logs_prefix | S3 prefix for ALB logs. | string | `alb` | no |
+| cloudtrail_cloudwatch_logs_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
 | cloudtrail_logs_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
 | config_logs_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
 | elb_logs_prefix | S3 prefix for ELB logs. | string | `elb` | no |
@@ -39,6 +41,7 @@ Logging from the following services is supported:
 | Name | Description |
 |------|-------------|
 | aws_logs_bucket | S3 bucket containing AWS logs. |
+| cloudtrail_cloudwatch_logs_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
 | cloudtrail_logs_path | S3 path for CloudTrail logs. |
 | configs_logs_path | S3 path for Config logs. |
 | elb_logs_path | S3 path for ELB logs. |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 /**
  * Creates and configures an S3 bucket for storing logs from various AWS
  * services and enables CloudTrail on all regions. Logs will expire after a
- * default of 90 days.
+ * default of 90 days. Includes support for sending CloudTrail events to a
+ * CloudWatch Logs group.
  *
  * Logging from the following services is supported:
  *
@@ -21,16 +22,22 @@
  *     }
  */
 
-// Get the account id of the AWS ELB service account in a given region for the
-// purpose of whitelisting in a S3 bucket policy.
+# Get the account id of the AWS ELB service account in a given region for the
+# purpose of whitelisting in a S3 bucket policy.
 data "aws_elb_service_account" "main" {}
 
-// Get the account id of the RedShift service account in a given region for the
-// purpose of allowing RedShift to store audit data in S3.
+# Get the account id of the RedShift service account in a given region for the
+# purpose of allowing RedShift to store audit data in S3.
 data "aws_redshift_service_account" "main" {}
 
-// JSON template defining all the access controls to allow AWS services to write
-// to this bucket
+# The AWS region currently being used.
+data "aws_region" "current" {}
+
+# The AWS account id
+data "aws_caller_identity" "current" {}
+
+# JSON template defining all the access controls to allow AWS services to write
+# to this bucket
 data "template_file" "aws_logs_policy" {
   template = "${file("${path.module}/policy.tpl")}"
 
@@ -45,6 +52,10 @@ data "template_file" "aws_logs_policy" {
     redshift_logs_prefix    = "${var.redshift_logs_prefix}"
   }
 }
+
+#
+# S3 Bucket
+#
 
 resource "aws_s3_bucket" "aws_logs" {
   bucket = "${var.s3_bucket_name}"
@@ -76,17 +87,88 @@ resource "aws_s3_bucket" "aws_logs" {
   }
 }
 
+#
+# IAM
+#
+
+data "aws_iam_policy_document" "cloudtrail_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals = {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudtrail_cloudwarch_logs" {
+  statement {
+    sid = "WriteCloudWatchLogs"
+
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.cloudtrail_cloudwatch_logs_group}:*"]
+  }
+}
+
+resource "aws_iam_role" "main" {
+  count              = "${var.enable_cloudtrail ? 1 : 0}"
+  name               = "cloudtrail-cloudwatch-logs-role"
+  assume_role_policy = "${data.aws_iam_policy_document.cloudtrail_assume_role.json}"
+}
+
+resource "aws_iam_policy" "main" {
+  count  = "${var.enable_cloudtrail ? 1 : 0}"
+  name   = "cloudtrail-cloudwatch-logs-policy"
+  policy = "${data.aws_iam_policy_document.cloudtrail_cloudwarch_logs.json}"
+}
+
+resource "aws_iam_policy_attachment" "main" {
+  count      = "${var.enable_cloudtrail ? 1 : 0}"
+  name       = "cloudtrail-cloudwatch-logs-policy-attachment"
+  policy_arn = "${aws_iam_policy.main.arn}"
+  roles      = ["${aws_iam_role.main.name}"]
+}
+
+#
+# CloudWatch Logs
+#
+
+resource "aws_cloudwatch_log_group" "main" {
+  count             = "${var.enable_cloudtrail ? 1 : 0}"
+  name              = "${var.cloudtrail_cloudwatch_logs_group}"
+  retention_in_days = "${var.expiration}"
+}
+
+#
+# CloudTrail
+#
+
 resource "aws_cloudtrail" "cloudtrail" {
+  depends_on = [
+    "aws_cloudwatch_log_group.main",
+  ]
+
   count = "${var.enable_cloudtrail ? 1 : 0}"
+
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.main.arn}"
+  cloud_watch_logs_role_arn  = "${aws_iam_role.main.arn}"
 
   name           = "cloudtrail"
   s3_key_prefix  = "cloudtrail"
   s3_bucket_name = "${var.s3_bucket_name}"
 
-  // use a single s3 bucket for all aws regions
+  # use a single s3 bucket for all aws regions
   is_multi_region_trail = true
 
-  // enable log file validation to detect tampering
+  # enable log file validation to detect tampering
   enable_log_file_validation = true
   depends_on                 = ["aws_s3_bucket.aws_logs"]
 }

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ data "aws_iam_policy_document" "cloudtrail_assume_role" {
   }
 }
 
-data "aws_iam_policy_document" "cloudtrail_cloudwarch_logs" {
+data "aws_iam_policy_document" "cloudtrail_cloudwatch_logs" {
   statement {
     sid = "WriteCloudWatchLogs"
 
@@ -127,7 +127,7 @@ resource "aws_iam_role" "main" {
 resource "aws_iam_policy" "main" {
   count  = "${var.enable_cloudtrail ? 1 : 0}"
   name   = "cloudtrail-cloudwatch-logs-policy"
-  policy = "${data.aws_iam_policy_document.cloudtrail_cloudwarch_logs.json}"
+  policy = "${data.aws_iam_policy_document.cloudtrail_cloudwatch_logs.json}"
 }
 
 resource "aws_iam_policy_attachment" "main" {
@@ -154,6 +154,7 @@ resource "aws_cloudwatch_log_group" "main" {
 resource "aws_cloudtrail" "cloudtrail" {
   depends_on = [
     "aws_cloudwatch_log_group.main",
+    "aws_s3_bucket.aws_logs",
   ]
 
   count = "${var.enable_cloudtrail ? 1 : 0}"
@@ -170,5 +171,4 @@ resource "aws_cloudtrail" "cloudtrail" {
 
   # enable log file validation to detect tampering
   enable_log_file_validation = true
-  depends_on                 = ["aws_s3_bucket.aws_logs"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "aws_logs_bucket" {
   value       = "${aws_s3_bucket.aws_logs.id}"
 }
 
+output "cloudtrail_cloudwatch_logs_arn" {
+  description = "The ARN of the CloudWatch Logs group storing CloudTrail Events."
+  value       = "${aws_cloudwatch_log_group.main.*.arn}"
+}
+
 output "cloudtrail_logs_path" {
   description = "S3 path for CloudTrail logs."
   value       = "${var.cloudtrail_logs_prefix}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "cloudtrail_cloudwatch_logs_group" {
+  description = "The name of the CloudWatch Logs group to send CloudTrail events."
+  default     = "cloudtrail-events"
+  type        = "string"
+}
+
 variable "s3_bucket_name" {
   description = "S3 bucket to store AWS logs in."
   type        = "string"


### PR DESCRIPTION
Having CloudTrail send events to CloudWatch Logs means we can start generating alarms and filters around certain sensitive events like disabling CloudTrail :). I also update the CircleCI image, pre-commit hooks and general comment cleanup.