### PR TITLE
Add prefix logging for NLBs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ data "template_file" "aws_logs_policy" {
     elb_log_account_arn     = "${data.aws_elb_service_account.main.arn}"
     elb_logs_prefix         = "${var.elb_logs_prefix}"
     alb_logs_prefix         = "${var.alb_logs_prefix}"
+    nlb_logs_prefix         = "${var.nlb_logs_prefix}"
     redshift_log_account_id = "${data.aws_redshift_service_account.main.id}"
     redshift_logs_prefix    = "${var.redshift_logs_prefix}"
   }

--- a/policy.tpl
+++ b/policy.tpl
@@ -69,6 +69,19 @@
       "Sid": "alb-logs-put-object"
     },
     {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "${elb_log_account_arn}"
+        ]
+      },
+      "Resource": "arn:aws:s3:::${bucket}/${nlb_logs_prefix}/*",
+      "Sid": "nlb-logs-put-object"
+    },
+    {
       "Action": "s3:PutObject",
       "Effect": "Allow",
       "Principal": {

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,12 @@ variable "alb_logs_prefix" {
   type        = "string"
 }
 
+variable "nlb_logs_prefix" {
+  description = "S3 prefix for NLB logs."
+  default     = "nlb"
+  type        = "string"
+}
+
 variable "cloudtrail_logs_prefix" {
   description = "S3 prefix for CloudTrail logs."
   default     = "cloudtrail"


### PR DESCRIPTION
More load balancer types means more load balancer logs. This PR add a prefix path for writing logs from Network Load Balancers (NLB).  The default is to allow writes to "nlb/".