### PR TITLE
update readme to reflect accurate var name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: trussworks/circleci-docker-primary:a9f8bd446144cc09126bdb3905615c4e7dd6af80
+      - image: trussworks/circleci-docker-primary:b3a0c4f25f01672c6dc45d066972195deda7ea49
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v1.3.0
+    rev: v2.1.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.11.0
+    rev: v0.13.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.7.3
+    rev: v1.8.1
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Creates and configures an S3 bucket for storing logs from various AWS
 services and enables CloudTrail on all regions. Logs will expire after a
 default of 90 days. Includes support for sending CloudTrail events to a
@@ -14,36 +15,36 @@ Logging from the following services is supported:
 ## Usage
 
     module "aws_logs" {
-      source         = "trussworks/aws/logs"
+      source         = "trussworks/logs/aws"
       s3_bucket_name = "my-company-aws-logs"
       region         = "us-west-2"
       expiration     = 90
     }
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb_logs_prefix | S3 prefix for ALB logs. | string | `alb` | no |
-| cloudtrail_cloudwatch_logs_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
-| cloudtrail_logs_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
-| config_logs_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
-| elb_logs_prefix | S3 prefix for ELB logs. | string | `elb` | no |
-| enable_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |
+| alb\_logs\_prefix | S3 prefix for ALB logs. | string | `alb` | no |
+| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
+| cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
+| config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
+| elb\_logs\_prefix | S3 prefix for ELB logs. | string | `elb` | no |
+| enable\_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |
 | expiration | Number of days to keep AWS logs around. | string | `90` | no |
-| redshift_logs_prefix | S3 prefix for RedShift logs. | string | `redshift` | no |
+| redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `redshift` | no |
 | region | Region where the AWS S3 bucket will be created. | string | - | yes |
-| s3_bucket_name | S3 bucket to store AWS logs in. | string | - | yes |
+| s3\_bucket\_name | S3 bucket to store AWS logs in. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| aws_logs_bucket | S3 bucket containing AWS logs. |
-| cloudtrail_cloudwatch_logs_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
-| cloudtrail_logs_path | S3 path for CloudTrail logs. |
-| configs_logs_path | S3 path for Config logs. |
-| elb_logs_path | S3 path for ELB logs. |
-| redshift_logs_path | S3 path for RedShift logs. |
+| aws\_logs\_bucket | S3 bucket containing AWS logs. |
+| cloudtrail\_cloudwatch\_logs\_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
+| cloudtrail\_logs\_path | S3 path for CloudTrail logs. |
+| configs\_logs\_path | S3 path for Config logs. |
+| elb\_logs\_path | S3 path for ELB logs. |
+| redshift\_logs\_path | S3 path for RedShift logs. |
 
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@
  * ## Usage
  *
  *     module "aws_logs" {
- *       source         = "trussworks/aws/logs"
+ *       source         = "trussworks/logs/aws"
  *       s3_bucket_name = "my-company-aws-logs"
  *       region         = "us-west-2"
  *       expiration     = 90


### PR DESCRIPTION
Readme used 
`source         = "trussworks/aws/logs"`
updated to 
`source         = "trussworks/logs/aws"`

Also have changed README to autoupdate.
