### PR TITLE
Enable CloudWatch Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Logging from the following services is supported:
 | alb\_logs\_prefix | S3 prefix for ALB logs. | string | `alb` | no |
 | cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
 | cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
+| cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `cloudwatch` | no |
 | config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | string | `elb` | no |
 | enable\_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,9 @@ data "template_file" "aws_logs_policy" {
   template = "${file("${path.module}/policy.tpl")}"
 
   vars = {
+    region                  = "${var.region}"
     bucket                  = "${var.s3_bucket_name}"
+    cloudwatch_logs_prefix  = "${var.cloudwatch_logs_prefix}"
     cloudtrail_logs_prefix  = "${var.cloudtrail_logs_prefix}"
     config_logs_prefix      = "${var.config_logs_prefix}"
     elb_log_account_arn     = "${data.aws_elb_service_account.main.arn}"

--- a/policy.tpl
+++ b/policy.tpl
@@ -43,6 +43,29 @@
       "Sid": "cloudtrail-logs-put-object"
     },
     {
+      "Action": "s3:GetBucketAcl",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logs.${region}.amazonaws.com"
+      },
+      "Resource": "arn:aws:s3:::${bucket}",
+      "Sid": "cloudwatch-logs-get-bucket-acl"
+    },
+    {
+      "Action": "s3:PutObject",
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logs.${region}.amazonaws.com"
+      },
+      "Resource": "arn:aws:s3:::${bucket}/${cloudwatch_logs_prefix}/*",
+      "Sid": "cloudwatch-logs-put-object"
+    },
+    {
       "Action": [
         "s3:PutObject"
       ],

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,12 @@ variable "alb_logs_prefix" {
   type        = "string"
 }
 
+variable "cloudwatch_logs_prefix" {
+  description = "S3 prefix for CloudWatch log exports."
+  default     = "cloudwatch"
+  type        = "string"
+}
+
 variable "cloudtrail_logs_prefix" {
   description = "S3 prefix for CloudTrail logs."
   default     = "cloudtrail"


### PR DESCRIPTION
This PR enables CloudWatch exports to the S3 bucket, which would be useful for creating backups of logs during delicate infrastructure operations.