### PR TITLE
separate cloudwatch log group retention var from aws log expiration var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,29 +23,30 @@ Logging from the following services is supported:
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alb\_logs\_prefix | S3 prefix for ALB logs. | string | `alb` | no |
-| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
-| cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
-| cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `cloudwatch` | no |
-| config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
-| elb\_logs\_prefix | S3 prefix for ELB logs. | string | `elb` | no |
-| enable\_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |
-| expiration | Number of days to keep AWS logs around. | string | `90` | no |
-| redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `redshift` | no |
-| region | Region where the AWS S3 bucket will be created. | string | - | yes |
-| s3\_bucket\_name | S3 bucket to store AWS logs in. | string | - | yes |
+| Name                                | Description                                                      |  Type  |       Default       | Required |
+| ----------------------------------- | ---------------------------------------------------------------- | :----: | :-----------------: | :------: |
+| alb\_logs\_prefix                   | S3 prefix for ALB logs.                                          | string |        `alb`        |    no    |
+| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` |    no    |
+| cloudtrail\_logs\_prefix            | S3 prefix for CloudTrail logs.                                   | string |    `cloudtrail`     |    no    |
+| cloudwatch\_log\_group\_retention   | Number of days to keep AWS logs around in specific log group.    | string |        `90`         |    no    |
+| cloudwatch\_logs\_prefix            | S3 prefix for CloudWatch log exports.                            | string |    `cloudwatch`     |    no    |
+| config\_logs\_prefix                | S3 prefix for AWS Config logs.                                   | string |      `config`       |    no    |
+| elb\_logs\_prefix                   | S3 prefix for ELB logs.                                          | string |        `elb`        |    no    |
+| enable\_cloudtrail                  | Enable CloudTrail to log to the AWS logs bucket.                 | string |       `true`        |    no    |
+| expiration                          | Number of days to keep AWS logs around.                          | string |        `90`         |    no    |
+| redshift\_logs\_prefix              | S3 prefix for RedShift logs.                                     | string |     `redshift`      |    no    |
+| region                              | Region where the AWS S3 bucket will be created.                  | string |          -          |   yes    |
+| s3\_bucket\_name                    | S3 bucket to store AWS logs in.                                  | string |          -          |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| aws\_logs\_bucket | S3 bucket containing AWS logs. |
+| Name                              | Description                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| aws\_logs\_bucket                 | S3 bucket containing AWS logs.                                  |
 | cloudtrail\_cloudwatch\_logs\_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
-| cloudtrail\_logs\_path | S3 path for CloudTrail logs. |
-| configs\_logs\_path | S3 path for Config logs. |
-| elb\_logs\_path | S3 path for ELB logs. |
-| redshift\_logs\_path | S3 path for RedShift logs. |
+| cloudtrail\_logs\_path            | S3 path for CloudTrail logs.                                    |
+| configs\_logs\_path               | S3 path for Config logs.                                        |
+| elb\_logs\_path                   | S3 path for ELB logs.                                           |
+| redshift\_logs\_path              | S3 path for RedShift logs.                                      |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -18,35 +18,35 @@ Logging from the following services is supported:
       source         = "trussworks/logs/aws"
       s3_bucket_name = "my-company-aws-logs"
       region         = "us-west-2"
-      expiration     = 90
+      s3_log_bucket_retention     = 90
     }
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alb\_logs\_prefix | S3 prefix for ALB logs. | string | `alb` | no |
-| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
-| cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
-| cloudwatch\_log\_group\_retention | Number of days to keep AWS logs around in specific log group. | string | `90` | no |
-| cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `cloudwatch` | no |
-| config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
-| elb\_logs\_prefix | S3 prefix for ELB logs. | string | `elb` | no |
-| enable\_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |
-| expiration | Number of days to keep AWS logs around. | string | `90` | no |
-| redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `redshift` | no |
-| region | Region where the AWS S3 bucket will be created. | string | - | yes |
-| s3\_bucket\_name | S3 bucket to store AWS logs in. | string | - | yes |
+| Name                                | Description                                                      |  Type  |       Default       | Required |
+| ----------------------------------- | ---------------------------------------------------------------- | :----: | :-----------------: | :------: |
+| alb\_logs\_prefix                   | S3 prefix for ALB logs.                                          | string |        `alb`        |    no    |
+| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` |    no    |
+| cloudtrail\_logs\_prefix            | S3 prefix for CloudTrail logs.                                   | string |    `cloudtrail`     |    no    |
+| cloudwatch\_log\_group\_retention   | Number of days to keep AWS logs around in specific log group.    | string |        `90`         |    no    |
+| cloudwatch\_logs\_prefix            | S3 prefix for CloudWatch log exports.                            | string |    `cloudwatch`     |    no    |
+| config\_logs\_prefix                | S3 prefix for AWS Config logs.                                   | string |      `config`       |    no    |
+| elb\_logs\_prefix                   | S3 prefix for ELB logs.                                          | string |        `elb`        |    no    |
+| enable\_cloudtrail                  | Enable CloudTrail to log to the AWS logs bucket.                 | string |       `true`        |    no    |
+| redshift\_logs\_prefix              | S3 prefix for RedShift logs.                                     | string |     `redshift`      |    no    |
+| region                              | Region where the AWS S3 bucket will be created.                  | string |          -          |   yes    |
+| s3\_bucket\_name                    | S3 bucket to store AWS logs in.                                  | string |          -          |   yes    |
+| s3\_log\_bucket\_retention          | Number of days to keep AWS logs around in S3.                    | string |        `90`         |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| aws\_logs\_bucket | S3 bucket containing AWS logs. |
+| Name                              | Description                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| aws\_logs\_bucket                 | S3 bucket containing AWS logs.                                  |
 | cloudtrail\_cloudwatch\_logs\_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
-| cloudtrail\_logs\_path | S3 path for CloudTrail logs. |
-| configs\_logs\_path | S3 path for Config logs. |
-| elb\_logs\_path | S3 path for ELB logs. |
-| redshift\_logs\_path | S3 path for RedShift logs. |
+| cloudtrail\_logs\_path            | S3 path for CloudTrail logs.                                    |
+| configs\_logs\_path               | S3 path for Config logs.                                        |
+| elb\_logs\_path                   | S3 path for ELB logs.                                           |
+| redshift\_logs\_path              | S3 path for RedShift logs.                                      |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -23,30 +23,30 @@ Logging from the following services is supported:
 
 ## Inputs
 
-| Name                                | Description                                                      |  Type  |       Default       | Required |
-| ----------------------------------- | ---------------------------------------------------------------- | :----: | :-----------------: | :------: |
-| alb\_logs\_prefix                   | S3 prefix for ALB logs.                                          | string |        `alb`        |    no    |
-| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` |    no    |
-| cloudtrail\_logs\_prefix            | S3 prefix for CloudTrail logs.                                   | string |    `cloudtrail`     |    no    |
-| cloudwatch\_log\_group\_retention   | Number of days to keep AWS logs around in specific log group.    | string |        `90`         |    no    |
-| cloudwatch\_logs\_prefix            | S3 prefix for CloudWatch log exports.                            | string |    `cloudwatch`     |    no    |
-| config\_logs\_prefix                | S3 prefix for AWS Config logs.                                   | string |      `config`       |    no    |
-| elb\_logs\_prefix                   | S3 prefix for ELB logs.                                          | string |        `elb`        |    no    |
-| enable\_cloudtrail                  | Enable CloudTrail to log to the AWS logs bucket.                 | string |       `true`        |    no    |
-| redshift\_logs\_prefix              | S3 prefix for RedShift logs.                                     | string |     `redshift`      |    no    |
-| region                              | Region where the AWS S3 bucket will be created.                  | string |          -          |   yes    |
-| s3\_bucket\_name                    | S3 bucket to store AWS logs in.                                  | string |          -          |   yes    |
-| s3\_log\_bucket\_retention          | Number of days to keep AWS logs around in S3.                    | string |        `90`         |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alb\_logs\_prefix | S3 prefix for ALB logs. | string | `alb` | no |
+| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
+| cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
+| cloudwatch\_log\_group\_retention | Number of days to keep AWS logs around in specific log group. | string | `90` | no |
+| cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `cloudwatch` | no |
+| config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
+| elb\_logs\_prefix | S3 prefix for ELB logs. | string | `elb` | no |
+| enable\_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |
+| redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `redshift` | no |
+| region | Region where the AWS S3 bucket will be created. | string | - | yes |
+| s3\_bucket\_name | S3 bucket to store AWS logs in. | string | - | yes |
+| s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | string | `90` | no |
 
 ## Outputs
 
-| Name                              | Description                                                     |
-| --------------------------------- | --------------------------------------------------------------- |
-| aws\_logs\_bucket                 | S3 bucket containing AWS logs.                                  |
+| Name | Description |
+|------|-------------|
+| aws\_logs\_bucket | S3 bucket containing AWS logs. |
 | cloudtrail\_cloudwatch\_logs\_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
-| cloudtrail\_logs\_path            | S3 path for CloudTrail logs.                                    |
-| configs\_logs\_path               | S3 path for Config logs.                                        |
-| elb\_logs\_path                   | S3 path for ELB logs.                                           |
-| redshift\_logs\_path              | S3 path for RedShift logs.                                      |
+| cloudtrail\_logs\_path | S3 path for CloudTrail logs. |
+| configs\_logs\_path | S3 path for Config logs. |
+| elb\_logs\_path | S3 path for ELB logs. |
+| redshift\_logs\_path | S3 path for RedShift logs. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -23,30 +23,30 @@ Logging from the following services is supported:
 
 ## Inputs
 
-| Name                                | Description                                                      |  Type  |       Default       | Required |
-| ----------------------------------- | ---------------------------------------------------------------- | :----: | :-----------------: | :------: |
-| alb\_logs\_prefix                   | S3 prefix for ALB logs.                                          | string |        `alb`        |    no    |
-| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` |    no    |
-| cloudtrail\_logs\_prefix            | S3 prefix for CloudTrail logs.                                   | string |    `cloudtrail`     |    no    |
-| cloudwatch\_log\_group\_retention   | Number of days to keep AWS logs around in specific log group.    | string |        `90`         |    no    |
-| cloudwatch\_logs\_prefix            | S3 prefix for CloudWatch log exports.                            | string |    `cloudwatch`     |    no    |
-| config\_logs\_prefix                | S3 prefix for AWS Config logs.                                   | string |      `config`       |    no    |
-| elb\_logs\_prefix                   | S3 prefix for ELB logs.                                          | string |        `elb`        |    no    |
-| enable\_cloudtrail                  | Enable CloudTrail to log to the AWS logs bucket.                 | string |       `true`        |    no    |
-| expiration                          | Number of days to keep AWS logs around.                          | string |        `90`         |    no    |
-| redshift\_logs\_prefix              | S3 prefix for RedShift logs.                                     | string |     `redshift`      |    no    |
-| region                              | Region where the AWS S3 bucket will be created.                  | string |          -          |   yes    |
-| s3\_bucket\_name                    | S3 bucket to store AWS logs in.                                  | string |          -          |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alb\_logs\_prefix | S3 prefix for ALB logs. | string | `alb` | no |
+| cloudtrail\_cloudwatch\_logs\_group | The name of the CloudWatch Logs group to send CloudTrail events. | string | `cloudtrail-events` | no |
+| cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `cloudtrail` | no |
+| cloudwatch\_log\_group\_retention | Number of days to keep AWS logs around in specific log group. | string | `90` | no |
+| cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `cloudwatch` | no |
+| config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `config` | no |
+| elb\_logs\_prefix | S3 prefix for ELB logs. | string | `elb` | no |
+| enable\_cloudtrail | Enable CloudTrail to log to the AWS logs bucket. | string | `true` | no |
+| expiration | Number of days to keep AWS logs around. | string | `90` | no |
+| redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `redshift` | no |
+| region | Region where the AWS S3 bucket will be created. | string | - | yes |
+| s3\_bucket\_name | S3 bucket to store AWS logs in. | string | - | yes |
 
 ## Outputs
 
-| Name                              | Description                                                     |
-| --------------------------------- | --------------------------------------------------------------- |
-| aws\_logs\_bucket                 | S3 bucket containing AWS logs.                                  |
+| Name | Description |
+|------|-------------|
+| aws\_logs\_bucket | S3 bucket containing AWS logs. |
 | cloudtrail\_cloudwatch\_logs\_arn | The ARN of the CloudWatch Logs group storing CloudTrail Events. |
-| cloudtrail\_logs\_path            | S3 path for CloudTrail logs.                                    |
-| configs\_logs\_path               | S3 path for Config logs.                                        |
-| elb\_logs\_path                   | S3 path for ELB logs.                                           |
-| redshift\_logs\_path              | S3 path for RedShift logs.                                      |
+| cloudtrail\_logs\_path | S3 path for CloudTrail logs. |
+| configs\_logs\_path | S3 path for Config logs. |
+| elb\_logs\_path | S3 path for ELB logs. |
+| redshift\_logs\_path | S3 path for RedShift logs. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
  *       source         = "trussworks/logs/aws"
  *       s3_bucket_name = "my-company-aws-logs"
  *       region         = "us-west-2"
- *       expiration     = 90
+ *       s3_log_bucket_retention     = 90
  *     }
  */
 
@@ -71,8 +71,8 @@ resource "aws_s3_bucket" "aws_logs" {
     prefix  = "/*"
     enabled = true
 
-    expiration {
-      days = "${var.expiration}"
+    s3_log_bucket_retention {
+      days = "${var.s3_log_bucket_retention}"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_iam_policy_attachment" "main" {
 resource "aws_cloudwatch_log_group" "main" {
   count             = "${var.enable_cloudtrail ? 1 : 0}"
   name              = "${var.cloudtrail_cloudwatch_logs_group}"
-  retention_in_days = "${var.expiration}"
+  retention_in_days = "${var.cloudwatch_log_group_retention}"
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "expiration" {
   type        = "string"
 }
 
+variable "cloudwatch_log_group_retention" {
+  description = "Number of days to keep AWS logs around in specific log group."
+  default     = 90
+  type        = "string"
+}
+
 variable "enable_cloudtrail" {
   description = "Enable CloudTrail to log to the AWS logs bucket."
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "region" {
   type        = "string"
 }
 
-variable "expiration" {
+variable "s3_log_bucket_retention" {
   description = "Number of days to keep AWS logs around."
   default     = 90
   type        = "string"


### PR DESCRIPTION
We want to be able to set the cloudwatch log group retention separately from the expiration variable because the log group retention has a very specific policy around the number of days you can set it to. Decoupling these variables will allow us to throw off the yoke of that repressive policy for the lifecycle rule regarding log expiration for the aws_s3_bucket.