### PR TITLE
fix var name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_s3_bucket" "aws_logs" {
     prefix  = "/*"
     enabled = true
 
-    s3_log_bucket_retention {
+    expiration {
       days = "${var.s3_log_bucket_retention}"
     }
   }


### PR DESCRIPTION
I changed the name of the key for the lifecycle rule when it should've been left "expiration".