### PR TITLE
Make creation of public_access_block optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,6 +264,8 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block" {
+  count = "${var.create_public_access_block ? 1 : 0}"
+
   depends_on = ["aws_s3_bucket_policy.bucket_policy"]
 
   bucket = "${aws_s3_bucket.aws_logs.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,9 @@ variable "allow_redshift" {
   default     = false
   type        = "string"
 }
+
+variable "create_public_access_block" {
+  description = "Whether to create a public_access_block restricting public access to the bucket."
+  default     = true
+  type        = "string"
+}


### PR DESCRIPTION
Some companies (like mine) don't allow standard developers to modify the public access block since we do it at the account level. They get the following error (which isn't super helpful)

> error creating public access block policy for S3 bucket (...): AccessDenied: Access Denied
> status code: 403

This would allow end users to opt out of the block if they're unable to create one themselves. Not sure if you would want to add some sort of caveat that they should ensure it's being protected in other ways (eg, an account-wide block).