### PR TITLE
Allow an NLB to log to the S3 logging bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Logging from the following services is supported for both cases:
 | allow\_cloudwatch | Allow Cloudwatch service to export logs to bucket. | string | `"false"` | no |
 | allow\_config | Allow Config service to log to bucket. | string | `"false"` | no |
 | allow\_elb | Allow ELB service to log to bucket. | string | `"false"` | no |
+| allow\_nlb | Allow NLB service to log to bucket. | string | `"false"` | no |
 | allow\_redshift | Allow Redshift service to log to bucket. | string | `"false"` | no |
 | cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `"cloudtrail"` | no |
 | cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `"cloudwatch"` | no |
 | config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `"config"` | no |
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | string | `"true"` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | string | `"elb"` | no |
+| nlb\_logs\_prefix | S3 prefix for NLB logs. | string | `"nlb"` | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | string | `"redshift"` | no |
 | region | Region where the AWS S3 bucket will be created. | string | n/a | yes |
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) list. | string | `"log-delivery-write"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "alb_logs_prefix" {
   type        = "string"
 }
 
+variable "nlb_logs_prefix" {
+  description = "S3 prefix for NLB logs."
+  default     = "nlb"
+  type        = "string"
+}
+
 variable "cloudwatch_logs_prefix" {
   description = "S3 prefix for CloudWatch log exports."
   default     = "cloudwatch"
@@ -77,6 +83,12 @@ variable "allow_cloudwatch" {
 
 variable "allow_alb" {
   description = "Allow ALB service to log to bucket."
+  default     = false
+  type        = "string"
+}
+
+variable "allow_nlb" {
+  description = "Allow NLB service to log to bucket."
   default     = false
   type        = "string"
 }


### PR DESCRIPTION
I discovered that the NLB is not doing access logging in https://github.com/trussworks/terraform-aws-nlb-containers/pull/9. However, to enable access logging the bucket must allow the NLB to write.