### PR TITLE
Secure S3 bucket from being written to by services on different accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Logging from the following services is supported for both cases:
 | cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | string | `"cloudtrail"` | no |
 | cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | string | `"cloudwatch"` | no |
 | config\_logs\_prefix | S3 prefix for AWS Config logs. | string | `"config"` | no |
+| create\_public\_access\_block | Whether to create a public_access_block restricting public access to the bucket. | string | `"true"` | no |
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | string | `"true"` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | string | `"elb"` | no |
 | nlb\_logs\_prefix | S3 prefix for NLB logs. | string | `"nlb"` | no |

--- a/main.tf
+++ b/main.tf
@@ -133,9 +133,10 @@ data "aws_iam_policy_document" "bucket_policy" {
     }
 
     resources = [
-        "arn:aws:s3:::${var.s3_bucket_name}/${var.cloudtrail_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+      "arn:aws:s3:::${var.s3_bucket_name}/${var.cloudtrail_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
     ]
-    sid       = "cloudtrail-logs-put-object"
+
+    sid = "cloudtrail-logs-put-object"
   }
 
   ## CloudWatch
@@ -218,7 +219,8 @@ data "aws_iam_policy_document" "bucket_policy" {
     resources = [
       "arn:aws:s3:::${var.s3_bucket_name}/${var.elb_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
     ]
-    sid       = "elb-logs-put-object"
+
+    sid = "elb-logs-put-object"
   }
 
   ## ALB
@@ -235,7 +237,8 @@ data "aws_iam_policy_document" "bucket_policy" {
     resources = [
       "arn:aws:s3:::${var.s3_bucket_name}/${var.alb_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
     ]
-    sid       = "alb-logs-put-object"
+
+    sid = "alb-logs-put-object"
   }
 
   ## NLB
@@ -258,7 +261,8 @@ data "aws_iam_policy_document" "bucket_policy" {
     resources = [
       "arn:aws:s3:::${var.s3_bucket_name}/${var.nlb_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
     ]
-    sid       = "nlb-logs-put-object"
+
+    sid = "nlb-logs-put-object"
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_s3_bucket" "aws_logs" {
 }
 
 data "aws_iam_policy_document" "bucket_policy" {
-  ## Cloudtrail
+  ## CloudTrail
   statement {
     actions = ["s3:GetBucketAcl"]
     effect  = "${(var.default_allow || var.allow_cloudtrail) ? "Allow" : "Deny"}"
@@ -132,11 +132,13 @@ data "aws_iam_policy_document" "bucket_policy" {
       identifiers = ["cloudtrail.amazonaws.com"]
     }
 
-    resources = ["arn:aws:s3:::${var.s3_bucket_name}/${var.cloudtrail_logs_prefix}/*"]
+    resources = [
+        "arn:aws:s3:::${var.s3_bucket_name}/${var.cloudtrail_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+    ]
     sid       = "cloudtrail-logs-put-object"
   }
 
-  ## Cloudwatch
+  ## CloudWatch
   statement {
     actions = ["s3:GetBucketAcl"]
     effect  = "${(var.default_allow || var.allow_cloudwatch) ? "Allow" : "Deny"}"
@@ -198,7 +200,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       identifiers = ["config.amazonaws.com"]
     }
 
-    resources = ["arn:aws:s3:::${var.s3_bucket_name}/${var.config_logs_prefix}/*"]
+    resources = ["arn:aws:s3:::${var.s3_bucket_name}/${var.config_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/Config/*"]
     sid       = "config-bucket-delivery"
   }
 
@@ -213,7 +215,9 @@ data "aws_iam_policy_document" "bucket_policy" {
       identifiers = ["${data.aws_elb_service_account.main.arn}"]
     }
 
-    resources = ["arn:aws:s3:::${var.s3_bucket_name}/${var.elb_logs_prefix}/*"]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}/${var.elb_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+    ]
     sid       = "elb-logs-put-object"
   }
 
@@ -228,7 +232,9 @@ data "aws_iam_policy_document" "bucket_policy" {
       identifiers = ["${data.aws_elb_service_account.main.arn}"]
     }
 
-    resources = ["arn:aws:s3:::${var.s3_bucket_name}/${var.alb_logs_prefix}/*"]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}/${var.alb_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+    ]
     sid       = "alb-logs-put-object"
   }
 
@@ -249,7 +255,9 @@ data "aws_iam_policy_document" "bucket_policy" {
       values   = ["bucket-owner-full-control"]
     }
 
-    resources = ["arn:aws:s3:::${var.s3_bucket_name}/${var.nlb_logs_prefix}/*"]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}/${var.nlb_logs_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+    ]
     sid       = "nlb-logs-put-object"
   }
 


### PR DESCRIPTION
tl;dr - Lock down bucket policies to the owner's account.

We noticed in our S3 bucket that AWS Config logs had been delivered from a different account. After investigating with AWS Support it appeared that our IAM policies were too permissive. Further investigation revealed that when I had been playing with AWS Config from a different account I used the same bucket name as my customer project so that my own logs went to the customer's S3 bucket. 

Fortunately AWS Support has confirmed that our bucket policies give the S3 bucket owner full ownership permissions and that my personal AWS account cannot access or read those logs.  This PR simply closes a potential hole where someone could abuse a service on a different account and cause it to log too many objects to our account.