### PR TITLE
fix to properly support ALB customizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:93fe471597189fed29f1ab2f517fc4c3370f2a77
+      - image: trussworks/circleci-docker-primary:782c370a89564e10e7ee00f6a6ad5c32309c11d5
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -129,13 +129,11 @@ Version 3.5.0 removed the `alb_logs_prefix` and `alb_accounts` variables and now
 
 Use the `format` and `formatlist` functions in the caller module to support more complex logging that does limit by account id.  For example:
 
-```
-alb_logs_prefixes = formatlist(format("alb/%%s/AWSLogs/%s", data.aws_caller_identity.current.account_id), [
- "hello-world-prod",
- "hello-world-staging",
- "hello-world-experimental",
-])
-```
+  alb_logs_prefixes = formatlist(format("alb/%%s/AWSLogs/%s", data.aws_caller_identity.current.account_id), [
+   "hello-world-prod",
+   "hello-world-staging",
+   "hello-world-experimental",
+  ])
 
 ### Upgrading from 2.1.X to 3.X.X
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ Logging from the following services is supported for both cases:
 
 ## Upgrade Paths
 
+### Upgrading from 3.4.0 to 3.5.x
+
+Version 3.5.0 removed the `alb_logs_prefix` and `alb_accounts` variables and now uses one `alb_logs_prefixes` list as input.  If you had not set the `alb_logs_prefix` or `alb_accounts` variables, then the default behavior does not change.  If you had set `alb_logs_prefix`, then simply pass the original value as a 1 item list to `alb_logs_prefixes` (while watching that path separators are not duplicated).  For example, `alb_logs_prefixes = ["logs/alb"]`.
+
+Use the `format` and `formatlist` functions in the caller module to support more complex logging that does limit by account id.  For example:
+
+```
+alb_logs_prefixes = formatlist(format("alb/%%s/AWSLogs/%s", data.aws_caller_identity.current.account_id), [
+ "hello-world-prod",
+ "hello-world-staging",
+ "hello-world-experimental",
+])
+```
+
 ### Upgrading from 2.1.X to 3.X.X
 
 Before upgrading you will want to make sure you are on the latest version of 2.1.X.

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ Version 3.5.0 removed the `alb_logs_prefix` and `alb_accounts` variables and now
 
 Use the `format` and `formatlist` functions in the caller module to support more complex logging that does limit by account id.  For example:
 
-  alb_logs_prefixes = formatlist(format("alb/%%s/AWSLogs/%s", data.aws_caller_identity.current.account_id), [
-   "hello-world-prod",
-   "hello-world-staging",
-   "hello-world-experimental",
-  ])
+    alb_logs_prefixes = formatlist(format("alb/%%s/AWSLogs/%s", data.aws_caller_identity.current.account_id), [
+      "hello-world-prod",
+      "hello-world-staging",
+      "hello-world-experimental",
+    ])
 
 ### Upgrading from 2.1.X to 3.X.X
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,26 @@ Logging from the following services is supported for both cases:
       cloudtrail_accounts = ["${data.aws_caller_identity.current.account_id}", "${aws_organizations_account.example.id}"]
     }
 
+## Usage for a single log bucket storing logs from multiple application load balancers
+
+    module "aws_logs" {
+      source         = "trussworks/logs/aws"
+      s3_bucket_name = "my-company-aws-logs-alb"
+      region         = "us-west-2"
+      default_allow  = false
+      allow_alb      = true
+      alb_logs_prefixes = formatlist(format("alb/%%s/AWSLogs/%s", data.aws_caller_identity.current.account_id), [
+       "hello-world-prod",
+       "hello-world-staging",
+       "hello-world-experimental",
+      ])
+    }
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb\_accounts | List of accounts for ALB logs.  By default limits to the current account. | list | `[]` | no |
-| alb\_logs\_prefix | S3 prefix for ALB logs. | string | `"alb"` | no |
+| alb\_logs\_prefixes | S3 key prefixes for ALB logs. | list | `[ "alb" ]` | no |
 | allow\_alb | Allow ALB service to log to bucket. | string | `"false"` | no |
 | allow\_cloudtrail | Allow Cloudtrail service to log to bucket. | string | `"false"` | no |
 | allow\_cloudwatch | Allow Cloudwatch service to export logs to bucket. | string | `"false"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,10 @@ variable "elb_logs_prefix" {
   type        = "string"
 }
 
-variable "alb_logs_prefix" {
-  description = "S3 prefix for ALB logs."
-  default     = "alb"
-  type        = "string"
+variable "alb_logs_prefixes" {
+  description = "S3 key prefixes for ALB logs."
+  default     = ["alb"]
+  type        = "list"
 }
 
 variable "nlb_logs_prefix" {
@@ -125,12 +125,6 @@ variable "cloudtrail_accounts" {
 
 variable "config_accounts" {
   description = "List of accounts for Config logs.  By default limits to the current account."
-  default     = []
-  type        = "list"
-}
-
-variable "alb_accounts" {
-  description = "List of accounts for ALB logs.  By default limits to the current account."
   default     = []
   type        = "list"
 }


### PR DESCRIPTION
Application Load Balancers were actually logging to a different prefix than assumed.  This PR allows us to limit bucket policy by multiple prefixes correctly.