### PR TITLE
Apply bucket policy directly to bucket resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ Terraform 0.11. Pin module version to ~> 3.5.0. Submit pull-requests to terrafor
 ### Upgrading from 4.0.0 to 4.1.x
 
 Version 4.1.0 removed the `aws_s3_bucket_policy` resource and now applies the bucket policy directly to the
-`aws_s3_bucket` resource. Upgrading a bucket to use version 4.1.0 of the module will update the bucket in-place, but
-will destroy and recreate the bucket policy.
+`aws_s3_bucket` resource to address an operation ordering issue when creating a cloudtrail and logs bucket in the same
+`terraform apply`. Upgrading a bucket to use version 4.1.0 of the module will update the bucket in-place, but will
+destroy and recreate the bucket policy.
 
 ### 4.0.0
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ Terraform 0.11. Pin module version to ~> 3.5.0. Submit pull-requests to terrafor
 
 ## Upgrade Paths
 
+### Upgrading from 4.0.0 to 4.1.x
+
+Version 4.1.0 removed the `aws_s3_bucket_policy` resource and now applies the bucket policy directly to the
+`aws_s3_bucket` resource. Upgrading a bucket to use version 4.1.0 of the module will update the bucket in-place, but
+will destroy and recreate the bucket policy.
+
+### 4.0.0
+
+Version 4.0.0 upgraded to Terraform 12 syntax.
+
 ### Upgrading from 3.4.0 to 3.5.x
 
 Version 3.5.0 removed the `alb_logs_prefix` and `alb_accounts` variables and now uses one `alb_logs_prefixes` list as input.  If you had not set the `alb_logs_prefix` or `alb_accounts` variables, then the default behavior does not change.  If you had set `alb_logs_prefix`, then simply pass the original value as a 1 item list to `alb_logs_prefixes` (while watching that path separators are not duplicated).  For example, `alb_logs_prefixes = ["logs/alb"]`.

--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -1,0 +1,11 @@
+module "aws_logs" {
+  source         = "../../"
+  s3_bucket_name = var.logs_bucket
+  region         = var.region
+}
+
+module "aws_cloudtrail" {
+  source         = "trussworks/cloudtrail/aws"
+  version        = "~> 2"
+  s3_bucket_name = module.aws_logs.aws_logs_bucket
+}

--- a/examples/cloudtrail/variables.tf
+++ b/examples/cloudtrail/variables.tf
@@ -1,0 +1,7 @@
+variable "logs_bucket" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -361,6 +361,7 @@ resource "aws_s3_bucket" "aws_logs" {
   bucket = var.s3_bucket_name
   acl    = var.s3_bucket_acl
   region = var.region
+  policy = data.template_file.bucket_policy.rendered
 
   lifecycle_rule {
     id      = "expire_all_logs"
@@ -386,15 +387,8 @@ resource "aws_s3_bucket" "aws_logs" {
   }
 }
 
-resource "aws_s3_bucket_policy" "bucket_policy" {
-  bucket = aws_s3_bucket.aws_logs.id
-  policy = data.template_file.bucket_policy.rendered
-}
-
 resource "aws_s3_bucket_public_access_block" "public_access_block" {
   count = var.create_public_access_block ? 1 : 0
-
-  depends_on = [aws_s3_bucket_policy.bucket_policy]
 
   bucket = aws_s3_bucket.aws_logs.id
 

--- a/test/terraform_aws_logs_cloudtrail_test.go
+++ b/test/terraform_aws_logs_cloudtrail_test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestTerraformAwsLogsCloudtrail(t *testing.T) {
+	t.Parallel()
+
+	expectedLogsBucket := fmt.Sprintf("terratest-aws-logs-cloudtrail-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/cloudtrail/",
+		Vars: map[string]interface{}{
+			"region":      awsRegion,
+			"logs_bucket": expectedLogsBucket,
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Empty logs_bucket before terraform destroy
+	aws.EmptyS3Bucket(t, awsRegion, expectedLogsBucket)
+}


### PR DESCRIPTION
Prior to this change, attempts to create a cloudtrail using this logs
bucket would fail initially with an InsufficientS3BucketPolicyException.
It was an ordering issue, where the cloudtrail would attempt to use the
s3 bucket before the subsequent policy attachment was complete. Running
a second terraform apply would work, but the logs bucket and cloudtrail
should be able to be created in the same terraform apply.

This change removes the aws_s3_bucket_policy resource and applies the
bucket policy directly in the aws_s3_bucket resource.

https://www.pivotaltracker.com/story/show/169575508

This PR adds a new terratest. Running the two terratests against our CI AWS account returns:

--- PASS: TestTerraformAwsLogs (34.94s)
--- PASS: TestTerraformAwsLogsCloudtrail (48.01s)
PASS
ok  	github.com/trussworks/terraform-aws-logs/test	48.376s