### PR TITLE
Add optional input to enable Cloudfront logging support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
       - run:
           name: Run pre-commit tests
-          command: pre-commit run --all-files
+          command: pre-commit run --all-files --show-diff-on-failure
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
+      - image: trussworks/circleci-docker-primary:30bf3333753c6283781e20ad9019b51e1f6cc0e4
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.25.0
+    rev: v1.27.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.23.6
+    rev: v1.23.8
     hooks:
       - id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     rev: v1.27.0
     hooks:
       - id: terraform_docs
-        types: [markdown]
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     rev: v1.27.0
     hooks:
       - id: terraform_docs
+        types: [markdown]
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ module "aws_logs" {
 | Name | Description |
 |------|-------------|
 | aws\_logs\_bucket | S3 bucket containing AWS logs. |
-| cloudfront\_logs\_path | S3 path for RedShift logs. |
+| cloudfront\_logs\_path | S3 path for Cloudfront logs. |
 | configs\_logs\_path | S3 path for Config logs. |
 | elb\_logs\_path | S3 path for ELB logs. |
 | redshift\_logs\_path | S3 path for RedShift logs. |

--- a/README.md
+++ b/README.md
@@ -115,14 +115,16 @@ module "aws_logs" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| alb\_logs\_prefixes | S3 key prefixes for ALB logs. | `list(string)` | <pre>[<br>  "alb"<br>]<br></pre> | no |
+| alb\_logs\_prefixes | S3 key prefixes for ALB logs. | `list(string)` | <pre>[<br>  "alb"<br>]</pre> | no |
 | allow\_alb | Allow ALB service to log to bucket. | `string` | `false` | no |
+| allow\_cloudfront | Allow Cloudfront service to export logs to bucket. | `string` | `false` | no |
 | allow\_cloudtrail | Allow Cloudtrail service to log to bucket. | `string` | `false` | no |
 | allow\_cloudwatch | Allow Cloudwatch service to export logs to bucket. | `string` | `false` | no |
 | allow\_config | Allow Config service to log to bucket. | `string` | `false` | no |
 | allow\_elb | Allow ELB service to log to bucket. | `string` | `false` | no |
 | allow\_nlb | Allow NLB service to log to bucket. | `string` | `false` | no |
 | allow\_redshift | Allow Redshift service to log to bucket. | `string` | `false` | no |
+| cloudfront\_logs\_prefix | S3 prefix for CloudFront logs. | `string` | `"cloudfront"` | no |
 | cloudtrail\_accounts | List of accounts for CloudTrail logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | `string` | `"cloudtrail"` | no |
 | cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | `string` | `"cloudwatch"` | no |
@@ -133,7 +135,7 @@ module "aws_logs" {
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | `string` | `"elb"` | no |
 | force\_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
-| nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]<br></pre> | no |
+| nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
 | region | Region where the AWS S3 bucket will be created. | `string` | n/a | yes |
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
@@ -145,6 +147,7 @@ module "aws_logs" {
 | Name | Description |
 |------|-------------|
 | aws\_logs\_bucket | S3 bucket containing AWS logs. |
+| cloudfront\_logs\_path | S3 path for RedShift logs. |
 | configs\_logs\_path | S3 path for Config logs. |
 | elb\_logs\_path | S3 path for ELB logs. |
 | redshift\_logs\_path | S3 path for RedShift logs. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,6 @@ output "redshift_logs_path" {
 }
 
 output "cloudfront_logs_path" {
-  description = "S3 path for RedShift logs."
+  description = "S3 path for Cloudfront logs."
   value       = var.cloudfront_logs_prefix
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,7 @@ output "redshift_logs_path" {
   value       = var.redshift_logs_prefix
 }
 
+output "cloudfront_logs_path" {
+  description = "S3 path for RedShift logs."
+  value       = var.cloudfront_logs_prefix
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "cloudtrail_logs_prefix" {
   type        = string
 }
 
+variable "cloudfront_logs_prefix" {
+  description = "S3 prefix for CloudFront logs."
+  default     = "cloudfront"
+  type        = string
+}
+
 variable "redshift_logs_prefix" {
   description = "S3 prefix for RedShift logs."
   default     = "redshift"
@@ -71,6 +77,12 @@ variable "allow_cloudtrail" {
 
 variable "allow_cloudwatch" {
   description = "Allow Cloudwatch service to export logs to bucket."
+  default     = false
+  type        = string
+}
+
+variable "allow_cloudfront" {
+  description = "Allow Cloudfront service to export logs to bucket."
   default     = false
   type        = string
 }


### PR DESCRIPTION
- Adds `allow_cloudfront` and `cloudfront_logs_prefix` inputs for adding cloudfront permissions to the bucket policy
- Pins the circleci docker image to the first version when terraform-docs 0.8.2 was added
- Auto-updates the circle-ci config & shows diffs when hooks fail due to changed files
