### PR TITLE
Revert "Document that Cloudfront is supported"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Logging from the following services is supported for both cases as well as in AW
 * [Config](https://aws.amazon.com/config/)
 * [RedShift](https://aws.amazon.com/redshift/)
 * [S3](https://aws.amazon.com/s3/)
-* [CloudFront](https://aws.amazon.com/cloudfront/)
 
 ## Terraform Versions
 


### PR DESCRIPTION
On further reflection we want to have a better understanding of the weirdness with how Cloudfront is granting itself access to the logs bucket & some kind of plan for handling a possible future world where that changes before we document support.