### PR TITLE
(WIP) Munging the cloudtrail prefix for GovCloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
+      - image: trussworks/circleci-docker-primary:4013bb8c2428b3e2755d90a922abb2a6cea37ab4
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ module "aws_logs" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| alb\_logs\_prefixes | S3 key prefixes for ALB logs. | `list(string)` | <pre>[<br>  "alb"<br>]<br></pre> | no |
+| alb\_logs\_prefixes | S3 key prefixes for ALB logs. | `list(string)` | <pre>[<br>  "alb"<br>]</pre> | no |
 | allow\_alb | Allow ALB service to log to bucket. | `bool` | `false` | no |
 | allow\_cloudtrail | Allow Cloudtrail service to log to bucket. | `bool` | `false` | no |
 | allow\_cloudwatch | Allow Cloudwatch service to export logs to bucket. | `bool` | `false` | no |
@@ -133,7 +133,7 @@ module "aws_logs" {
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | `string` | `"elb"` | no |
 | force\_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
-| nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]<br></pre> | no |
+| nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
 | region | Region where the AWS S3 bucket will be created. | `string` | n/a | yes |
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ data "aws_partition" "current" {
 
 # Defining the "real" prefix for cloudtrail to get around GovCloud issues.
 locals {
-  cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
+  cloudtrail_real_prefix = var.cloudtrail_logs_prefix == "" ? "" : format("%s/", var.cloudtrail_logs_prefix)
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,9 @@ data "template_file" "bucket_policy" {
 }
 JSON
 
+  locals = {
+    cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
+  }
 
   vars = {
     region        = var.region
@@ -181,15 +184,14 @@ JSON
         var.cloudwatch_logs_prefix,
       ),
     )
-    cloudtrail_effect      = var.default_allow || var.allow_cloudtrail ? "Allow" : "Deny"
-    cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
+    cloudtrail_effect = var.default_allow || var.allow_cloudtrail ? "Allow" : "Deny"
     cloudtrail_resources = length(var.cloudtrail_accounts) > 0 ? jsonencode(
       sort(
         formatlist(
           format(
             "arn:${data.aws_partition.current.partition}:s3:::%s/%sAWSLogs/%%s/*",
             var.s3_bucket_name,
-            var.cloudtrail_real_prefix,
+            local.cloudtrail_real_prefix,
           ),
           var.cloudtrail_accounts,
         ),
@@ -198,7 +200,7 @@ JSON
       format(
         "arn:${data.aws_partition.current.partition}:s3:::%s/%s/AWSLogs/%s/*",
         var.s3_bucket_name,
-        var.cloudtrail_real_prefix,
+        local.cloudtrail_real_prefix,
         data.aws_caller_identity.current.account_id,
       ),
     )

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data "aws_partition" "current" {
 }
 
 # Defining the "real" prefix for cloudtrail to get around GovCloud issues.
-locals = {
+locals {
   cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -181,14 +181,15 @@ JSON
         var.cloudwatch_logs_prefix,
       ),
     )
-    cloudtrail_effect = var.default_allow || var.allow_cloudtrail ? "Allow" : "Deny"
+    cloudtrail_effect      = var.default_allow || var.allow_cloudtrail ? "Allow" : "Deny"
+    cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
     cloudtrail_resources = length(var.cloudtrail_accounts) > 0 ? jsonencode(
       sort(
         formatlist(
           format(
-            "arn:${data.aws_partition.current.partition}:s3:::%s/%s/AWSLogs/%%s/*",
+            "arn:${data.aws_partition.current.partition}:s3:::%s/%sAWSLogs/%%s/*",
             var.s3_bucket_name,
-            var.cloudtrail_logs_prefix,
+            var.cloudtrail_real_prefix,
           ),
           var.cloudtrail_accounts,
         ),
@@ -197,7 +198,7 @@ JSON
       format(
         "arn:${data.aws_partition.current.partition}:s3:::%s/%s/AWSLogs/%s/*",
         var.s3_bucket_name,
-        var.cloudtrail_logs_prefix,
+        var.cloudtrail_real_prefix,
         data.aws_caller_identity.current.account_id,
       ),
     )

--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ JSON
       ),
       ) : jsonencode(
       format(
-        "arn:${data.aws_partition.current.partition}:s3:::%s/%s/AWSLogs/%s/*",
+        "arn:${data.aws_partition.current.partition}:s3:::%s/%sAWSLogs/%s/*",
         var.s3_bucket_name,
         local.cloudtrail_real_prefix,
         data.aws_caller_identity.current.account_id,

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,11 @@ data "aws_caller_identity" "current" {
 data "aws_partition" "current" {
 }
 
+# Defining the "real" prefix for cloudtrail to get around GovCloud issues.
+locals = {
+  cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
+}
+
 #
 # S3 Bucket
 #
@@ -160,10 +165,6 @@ data "template_file" "bucket_policy" {
     ]
 }
 JSON
-
-  locals = {
-    cloudtrail_real_prefix = length(var.cloudtrail_logs_prefix) == 0 ? "" : format("%s/", var.cloudtrail_logs_prefix)
-  }
 
   vars = {
     region        = var.region


### PR DESCRIPTION
So, this is janky af, but in order to accommodate GovCloud, which has no prefix for the Cloudtrail logs in the autogenerated bucket it uses, I'm doing a little munging to see if there is no prefix for Cloudtrail. If there is, the path is `prefix/AWSLogs...`, while if there is not, it is `AWSLogs...`. The default will remain `cloudtrail`, so it won't break current deployments.

I've not tested this yet, so I'll hold off on any merging/releasing until I can confirm this works, both in the positive and negative case.