### PR TITLE
Drop region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Terraform 0.11. Pin module version to ~> 3.5.0 . Submit pull-requests to terrafo
 module "aws_logs" {
   source         = "trussworks/logs/aws"
   s3_bucket_name = "my-company-aws-logs"
-  region         = "us-west-2"
 }
 ```
 
@@ -38,7 +37,6 @@ module "aws_logs" {
 module "aws_logs" {
   source         = "trussworks/logs/aws"
   s3_bucket_name = "my-company-aws-logs-elb"
-  region         = "us-west-2"
   default_allow  = false
   allow_elb      = true
 }
@@ -50,7 +48,6 @@ module "aws_logs" {
 module "aws_logs" {
   source         = "trussworks/logs/aws"
   s3_bucket_name = "my-company-aws-logs-lb"
-  region         = "us-west-2"
   default_allow  = false
   allow_alb      = true
   allow_elb      = true
@@ -63,7 +60,6 @@ module "aws_logs" {
 module "aws_logs" {
   source              = "trussworks/logs/aws"
   s3_bucket_name      = "my-company-aws-logs-cloudtrail"
-  region              = "us-west-2"
   default_allow       = false
   allow_cloudtrail    = true
   cloudtrail_accounts = [data.aws_caller_identity.current.account_id, aws_organizations_account.example.id]
@@ -76,7 +72,6 @@ module "aws_logs" {
 module "aws_logs" {
   source            = "trussworks/logs/aws"
   s3_bucket_name    = "my-company-aws-logs-lb"
-      region            = "us-west-2"
       default_allow     = false
       allow_alb         = true
       allow_nlb         = true
@@ -91,6 +86,21 @@ module "aws_logs" {
        "nlb/hello-world-experimental",
       ]
     }
+```
+
+## Usage for a single log bucket in the region of an aliased provider
+
+```hcl
+module "aws_logs" {
+  source            = "trussworks/logs/aws"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  s3_bucket_name    = "my-company-aws-logs-lb"
+  default_allow     = false
+}
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -133,7 +143,6 @@ module "aws_logs" {
 | nlb\_account | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
 | nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
-| region | Region where the AWS S3 bucket will be created. | `string` | n/a | yes |
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
@@ -144,6 +153,7 @@ module "aws_logs" {
 | Name | Description |
 |------|-------------|
 | aws\_logs\_bucket | S3 bucket containing AWS logs. |
+| aws\_logs\_bucket\_arn | ARN of S3 bucket containing AWS logs. |
 | configs\_logs\_path | S3 path for Config logs. |
 | elb\_logs\_path | S3 path for ELB logs. |
 | redshift\_logs\_path | S3 path for RedShift logs. |
@@ -151,6 +161,14 @@ module "aws_logs" {
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Upgrade Paths
+
+### Upgrading from 9.0.0 to 10.x.x
+
+The `10.0.0` release removes the `region` variable to reflect what was done in the [3.0.0 release](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#300-july-31-2020) of the terraform provider for AWS.
+
+### Upgrading from 8.2.0 to 9.x.x
+
+The `9.0.0` release upgrades the terraform provider for AWS to version [3.0.0](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#300-july-31-2020).
 
 ### Upgrading from 6.0.0 to 7.x.x
 

--- a/examples/alb/main.tf
+++ b/examples/alb/main.tf
@@ -3,7 +3,6 @@ module "aws_logs" {
 
   s3_bucket_name    = var.test_name
   alb_logs_prefixes = var.alb_logs_prefixes
-  region            = var.region
   allow_alb         = true
   default_allow     = false
 

--- a/examples/alb/variables.tf
+++ b/examples/alb/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/alb_remote/main.tf
+++ b/examples/alb_remote/main.tf
@@ -6,7 +6,6 @@ module "aws_logs" {
 
   s3_bucket_name    = var.test_name
   alb_logs_prefixes = var.alb_logs_prefixes
-  region            = var.region
   allow_alb         = true
   default_allow     = false
 

--- a/examples/alb_remote/variables.tf
+++ b/examples/alb_remote/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -2,7 +2,6 @@ module "aws_logs" {
   source = "../../"
 
   s3_bucket_name         = var.test_name
-  region                 = var.region
   force_destroy          = var.force_destroy
   cloudtrail_logs_prefix = var.cloudtrail_logs_prefix
 

--- a/examples/cloudtrail/variables.tf
+++ b/examples/cloudtrail/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "force_destroy" {
   type = bool
 }

--- a/examples/combined/main.tf
+++ b/examples/combined/main.tf
@@ -2,7 +2,6 @@ module "aws_logs" {
   source = "../../"
 
   s3_bucket_name = var.test_name
-  region         = var.region
   default_allow  = true
 
   force_destroy = var.force_destroy

--- a/examples/combined/variables.tf
+++ b/examples/combined/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/config/main.tf
+++ b/examples/config/main.tf
@@ -2,7 +2,6 @@ module "aws_logs" {
   source = "../../"
 
   s3_bucket_name     = var.test_name
-  region             = var.region
   allow_config       = true
   default_allow      = false
   config_logs_prefix = var.config_logs_prefix

--- a/examples/config/variables.tf
+++ b/examples/config/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "force_destroy" {
   type = bool
 }

--- a/examples/elb/main.tf
+++ b/examples/elb/main.tf
@@ -3,7 +3,6 @@ module "aws_logs" {
 
   s3_bucket_name  = var.test_name
   elb_logs_prefix = var.elb_logs_prefix
-  region          = var.region
   allow_elb       = true
   default_allow   = false
 

--- a/examples/elb/variables.tf
+++ b/examples/elb/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/nlb/main.tf
+++ b/examples/nlb/main.tf
@@ -3,7 +3,6 @@ module "aws_logs" {
 
   s3_bucket_name    = var.test_name
   nlb_logs_prefixes = var.nlb_logs_prefixes
-  region            = var.region
   allow_nlb         = true
   default_allow     = false
 

--- a/examples/nlb/variables.tf
+++ b/examples/nlb/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/nlb_remote/main.tf
+++ b/examples/nlb_remote/main.tf
@@ -6,7 +6,6 @@ module "aws_logs" {
 
   s3_bucket_name    = var.test_name
   nlb_logs_prefixes = var.nlb_logs_prefixes
-  region            = var.region
   allow_nlb         = true
   default_allow     = false
 

--- a/examples/nlb_remote/variables.tf
+++ b/examples/nlb_remote/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/redshift/main.tf
+++ b/examples/redshift/main.tf
@@ -3,7 +3,6 @@ module "aws_logs" {
 
   s3_bucket_name       = var.test_name
   redshift_logs_prefix = var.redshift_logs_prefix
-  region               = var.region
   allow_redshift       = true
   default_allow        = false
 

--- a/examples/redshift/variables.tf
+++ b/examples/redshift/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "vpc_azs" {
   type = list(string)
 }

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -2,7 +2,6 @@ module "aws_logs" {
   source = "../../"
 
   s3_bucket_name = var.test_name
-  region         = var.region
 
   default_allow = false
 

--- a/examples/s3/variables.tf
+++ b/examples/s3/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "force_destroy" {
   type = bool
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,7 +2,6 @@ module "aws_logs" {
   source = "../../"
 
   s3_bucket_name = var.test_name
-  region         = var.region
 
   force_destroy = var.force_destroy
   tags          = var.tags

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -2,10 +2,6 @@ variable "test_name" {
   type = string
 }
 
-variable "region" {
-  type = string
-}
-
 variable "force_destroy" {
   type = bool
 }

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,10 @@ data "aws_redshift_service_account" "main" {
 data "aws_caller_identity" "current" {
 }
 
+# The current cregion
+data "aws_region" "current" {
+}
+
 # The AWS partition for differentiating between AWS commercial and GovCloud
 data "aws_partition" "current" {
 }
@@ -48,7 +52,9 @@ locals {
   cloudwatch_effect = var.default_allow || var.allow_cloudwatch ? "Allow" : "Deny"
 
   # region specific logs service principal
-  cloudwatch_service = "logs.${var.region}.amazonaws.com"
+  cloudwatch_service = format(
+    "logs.%s.amazonaws.com", data.aws_region.current.name
+  )
 
   cloudwatch_resource = "${local.bucket_arn}/${var.cloudwatch_logs_prefix}/*"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "aws_logs_bucket" {
   value       = aws_s3_bucket.aws_logs.id
 }
 
+output "aws_logs_bucket_arn" {
+  description = "ARN of S3 bucket containing AWS logs."
+  value       = aws_s3_bucket.aws_logs.arn
+}
+
 output "configs_logs_path" {
   description = "S3 path for Config logs."
   value       = var.config_logs_prefix
@@ -17,4 +22,3 @@ output "redshift_logs_path" {
   description = "S3 path for RedShift logs."
   value       = var.redshift_logs_prefix
 }
-

--- a/test/terraform_aws_logs_alb_test.go
+++ b/test/terraform_aws_logs_alb_test.go
@@ -41,7 +41,6 @@ func TestTerraformAwsLogsAlb(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":            awsRegion,
 			"vpc_azs":           vpcAzs,
 			"test_name":         testName,
 			"force_destroy":     true,
@@ -67,7 +66,6 @@ func TestTerraformAwsLogsAlbRootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":            awsRegion,
 			"vpc_azs":           vpcAzs,
 			"test_name":         testName,
 			"force_destroy":     true,
@@ -95,7 +93,6 @@ func TestTerraformAwsLogsAlbAccount(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":               awsRegion,
 			"vpc_azs":              vpcAzs,
 			"alb_external_account": externalAlbAccount,
 			"test_name":            testName,

--- a/test/terraform_aws_logs_cloudtrail_test.go
+++ b/test/terraform_aws_logs_cloudtrail_test.go
@@ -22,7 +22,6 @@ func TestTerraformAwsLogsCloudtrail(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":                 awsRegion,
 			"test_name":              testName,
 			"force_destroy":          true,
 			"cloudtrail_logs_prefix": testName,
@@ -44,7 +43,6 @@ func TestTerraformAwsLogsCloudtrailRootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":                 awsRegion,
 			"test_name":              testName,
 			"force_destroy":          true,
 			"cloudtrail_logs_prefix": "",

--- a/test/terraform_aws_logs_combined_test.go
+++ b/test/terraform_aws_logs_combined_test.go
@@ -26,7 +26,6 @@ func TestTerraformAwsLogsCombined(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":        awsRegion,
 			"vpc_azs":       vpcAzs,
 			"test_name":     testName,
 			"test_redshift": testRedshift,

--- a/test/terraform_aws_logs_config_test.go
+++ b/test/terraform_aws_logs_config_test.go
@@ -23,7 +23,6 @@ func TestTerraformAwsLogsConfig(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":             awsRegion,
 			"test_name":          testName,
 			"force_destroy":      true,
 			"config_logs_prefix": testName,
@@ -49,7 +48,6 @@ func TestTerraformAwsLogsConfigRootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":             awsRegion,
 			"test_name":          testName,
 			"force_destroy":      true,
 			"config_logs_prefix": "",

--- a/test/terraform_aws_logs_elb_test.go
+++ b/test/terraform_aws_logs_elb_test.go
@@ -22,7 +22,6 @@ func TestTerraformAwsLogsElb(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":          awsRegion,
 			"vpc_azs":         vpcAzs,
 			"test_name":       testName,
 			"force_destroy":   true,
@@ -48,7 +47,6 @@ func TestTerraformAwsLogsElbRootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":          awsRegion,
 			"vpc_azs":         vpcAzs,
 			"test_name":       testName,
 			"force_destroy":   true,

--- a/test/terraform_aws_logs_nlb_test.go
+++ b/test/terraform_aws_logs_nlb_test.go
@@ -30,7 +30,6 @@ func TestTerraformAwsLogsNlb(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":            awsRegion,
 			"vpc_azs":           vpcAzs,
 			"test_name":         testName,
 			"force_destroy":     true,
@@ -56,7 +55,6 @@ func TestTerraformAwsLogsNlbRootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":            awsRegion,
 			"vpc_azs":           vpcAzs,
 			"test_name":         testName,
 			"force_destroy":     true,
@@ -84,7 +82,6 @@ func TestTerraformAwsLogsNlbAccount(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":               awsRegion,
 			"vpc_azs":              vpcAzs,
 			"nlb_external_account": externalAlbAccount,
 			"test_name":            testName,

--- a/test/terraform_aws_logs_redshift_test.go
+++ b/test/terraform_aws_logs_redshift_test.go
@@ -26,7 +26,6 @@ func TestTerraformAwsLogsRedshift(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":               awsRegion,
 			"vpc_azs":              vpcAzs,
 			"test_name":            testName,
 			"force_destroy":        true,
@@ -56,7 +55,6 @@ func TestTerraformAwsLogsRedshiftRootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":               awsRegion,
 			"vpc_azs":              vpcAzs,
 			"test_name":            testName,
 			"force_destroy":        true,

--- a/test/terraform_aws_logs_s3_test.go
+++ b/test/terraform_aws_logs_s3_test.go
@@ -20,7 +20,6 @@ func TestTerraformAwsLogsS3(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":         awsRegion,
 			"test_name":      testName,
 			"force_destroy":  true,
 			"s3_logs_prefix": testName,
@@ -44,7 +43,6 @@ func TestTerraformAwsLogsS3RootPrefix(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":         awsRegion,
 			"test_name":      testName,
 			"force_destroy":  true,
 			"s3_logs_prefix": "",

--- a/test/terraform_aws_logs_test.go
+++ b/test/terraform_aws_logs_test.go
@@ -25,7 +25,6 @@ func TestTerraformAwsLogs(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":        awsRegion,
 			"test_name":     testName,
 			"force_destroy": true,
 		},
@@ -48,7 +47,6 @@ func TestTerraformAwsLogsWithConflictingTags(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: tempTestFolder,
 		Vars: map[string]interface{}{
-			"region":        awsRegion,
 			"test_name":     testName,
 			"force_destroy": true,
 			"tags": map[string]string{

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "s3_bucket_name" {
   type        = string
 }
 
-variable "region" {
-  description = "Region where the AWS S3 bucket will be created."
-  type        = string
-}
-
 variable "s3_log_bucket_retention" {
   description = "Number of days to keep AWS logs around."
   default     = 90


### PR DESCRIPTION
This PR makes the region variable optional, which simplifies creating log buckets in the regions for aliased providers as shown in the new section in the `README.md`.