### PR TITLE
Add option of enforcing TLS-only requests via the S3 bucket policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ module "aws_logs" {
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | `bool` | `true` | no |
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | `string` | `"elb"` | no |
+| enforce\_tls\_requests\_only | A bool to enable a policy to ensure only TLS requests to the bucket are permitted | `bool` | `false` | no |
 | force\_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
 | nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |

--- a/examples/enforce_tls/main.tf
+++ b/examples/enforce_tls/main.tf
@@ -1,0 +1,10 @@
+module "aws_logs" {
+  source = "../../"
+
+  s3_bucket_name = var.test_name
+  region         = var.region
+
+  enforce_tls_requests_only = var.enforce_tls_requests_only
+
+  force_destroy = var.force_destroy
+}

--- a/examples/enforce_tls/variables.tf
+++ b/examples/enforce_tls/variables.tf
@@ -1,0 +1,15 @@
+variable "test_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "enforce_tls_requests_only" {
+  type = bool
+}
+
+variable "force_destroy" {
+  type = bool
+}

--- a/test/terraform_aws_logs_enforce_tls_test.go
+++ b/test/terraform_aws_logs_enforce_tls_test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+func TestTerraformAwsLogsEnforceTls(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/enforce_tls")
+	testName := fmt.Sprintf("terratest-aws-logs-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":                    awsRegion,
+			"test_name":                 testName,
+			"enforce_tls_requests_only": true,
+			"force_destroy":             true,
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "config_accounts" {
   type        = list(string)
 }
 
+variable "enforce_tls_requests_only" {
+  description = "A bool to enable a policy to ensure only TLS requests to the bucket are permitted"
+  default     = false
+  type        = bool
+}
+
 variable "elb_accounts" {
   description = "List of accounts for ELB logs.  By default limits to the current account."
   default     = []


### PR DESCRIPTION
This change allows an extra statement to be added to the log S3 bucket
policy that denies requests unless they're made via TLS.

This additional policy statement is necessary to be able to enforce
encryption-in-transit requirements alongside the encryption-at-rest
that's already handled by the
`apply_server_side_encryption_by_default` block on the S3 bucket
resource.

This policy is required for buckets managed by this module to pass the
AWS Config `s3-bucket-ssl-requests-only`[1] managed rule and
Prowler's[2] `extra764` check, which although not part of the CIS
benchmark seems like a sensible thing to satisfy.

Note that Trussworks' AWS Config module[3] enables the
s3-bucket-ssl-requests-only check by default, so before this change,
the two modules together result in failing Config checks.

By default insecure requests are permitted, in line with S3 defaults
and the historical behaviour of this module.

Note that this change does not appear to be implementable in a safe
manner following the pattern of other statements of flipping the
effect. My reading of explicitly allowing aws:SecureTransport requests
would have the effect of permitting all anonymous HTTP requests, which
is definitely not the opposite of denying any HTTP requests.

[1] https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html
[2] https://github.com/toniblyx/prowler
[3] https://github.com/trussworks/terraform-aws-config