### PR TITLE
Enforce TLS requests only by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:4013bb8c2428b3e2755d90a922abb2a6cea37ab4
+      - image: trussworks/circleci-docker-primary:b96e1e78ad66e43b3d0e54b4d936fa0fd32d8246
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ module "aws_logs" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -101,7 +107,7 @@ module "aws_logs" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alb\_logs\_prefixes | S3 key prefixes for ALB logs. | `list(string)` | <pre>[<br>  "alb"<br>]</pre> | no |
 | allow\_alb | Allow ALB service to log to bucket. | `bool` | `false` | no |
 | allow\_cloudtrail | Allow Cloudtrail service to log to bucket. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -316,6 +316,28 @@ data "aws_iam_policy_document" "main" {
     resources = [local.bucket_arn]
   }
 
+  #
+  # Enforce TLS requests only
+  #
+
+  statement {
+    sid    = "enforce-tls-requests-only"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = ["s3:*"]
+    resources = [
+      local.bucket_arn,
+      "${local.bucket_arn}/*"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 


### PR DESCRIPTION
This change adds an extra statement to the log S3 bucket policy that
denies requests unless they're made via TLS.

This additional policy statement is necessary to be able to enforce
encryption-in-transit requirements alongside the encryption-at-rest
that's already handled by the
`apply_server_side_encryption_by_default` block on the S3 bucket
resource.

This policy is required for buckets managed by this module to pass the
AWS Config `s3-bucket-ssl-requests-only`[1] managed rule and
Prowler's[2] `extra764` check, which although not part of the CIS
benchmark seems like a sensible thing to satisfy.

Note that Trussworks' AWS Config module[3] enables the
s3-bucket-ssl-requests-only check by default, so before this change,
the two modules together result in failing Config checks.

A previous PR (#61) was submitted which made this additional policy
optional, with the default unchanged, but it was agreed with @dynamike
that changing the default was more sensible.

[1] https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html
[2] https://github.com/toniblyx/prowler
[3] https://github.com/trussworks/terraform-aws-config