### PR TITLE
HOLD: Support for guardduty exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ module "aws_logs" {
 | allow\_cloudwatch | Allow Cloudwatch service to export logs to bucket. | `bool` | `false` | no |
 | allow\_config | Allow Config service to log to bucket. | `bool` | `false` | no |
 | allow\_elb | Allow ELB service to log to bucket. | `bool` | `false` | no |
+| allow\_guardduty | Allow GuardDuty service to log to bucket. | `bool` | `false` | no |
 | allow\_nlb | Allow NLB service to log to bucket. | `bool` | `false` | no |
 | allow\_redshift | Allow Redshift service to log to bucket. | `bool` | `false` | no |
 | cloudtrail\_accounts | List of accounts for CloudTrail logs.  By default limits to the current account. | `list(string)` | `[]` | no |
@@ -125,6 +126,7 @@ module "aws_logs" {
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | `string` | `"elb"` | no |
 | force\_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
+| guardduty\_logs\_prefixes | S3 key prefixes for GuardDuty logs. | `list(string)` | <pre>[<br>  "guardduty"<br>]</pre> | no |
 | nlb\_account | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
 | nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |

--- a/examples/guardduty/main.tf
+++ b/examples/guardduty/main.tf
@@ -1,0 +1,11 @@
+module "aws_logs" {
+  source = "../../"
+
+  s3_bucket_name          = var.test_name
+  guardduty_logs_prefixes = var.guardduty_logs_prefixes
+  region                  = var.region
+  allow_guardduty         = true
+  default_allow           = false
+
+  force_destroy = var.force_destroy
+}

--- a/examples/guardduty/variables.tf
+++ b/examples/guardduty/variables.tf
@@ -1,0 +1,15 @@
+variable "test_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "force_destroy" {
+  type = bool
+}
+
+variable "guardduty_logs_prefixes" {
+  type = list(string)
+}

--- a/test/terraform_aws_logs_guardduty_test.go
+++ b/test/terraform_aws_logs_guardduty_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+func TestTerraformAwsLogsGuardDuty(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/guardduty")
+	testName := fmt.Sprintf("terratest-aws-logs-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":            awsRegion,
+			"test_name":         testName,
+			"force_destroy":     true,
+			"guardduty_logs_prefixes": []string{testName},
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -100,6 +100,12 @@ variable "allow_redshift" {
   type        = bool
 }
 
+variable "allow_guardduty" {
+  description = "Allow GuardDuty service to log to bucket."
+  default     = false
+  type        = bool
+}
+
 variable "create_public_access_block" {
   description = "Whether to create a public_access_block restricting public access to the bucket."
   default     = true
@@ -152,4 +158,10 @@ variable tags {
   type        = map(string)
   default     = {}
   description = "A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag."
+}
+
+variable "guardduty_logs_prefixes" {
+  description = "S3 key prefixes for GuardDuty logs."
+  default     = ["guardduty"]
+  type        = list(string)
 }


### PR DESCRIPTION
This PR includes support for GuardDuty logs.  I also added some comments to the source code on why the paths are what they are.  Now sure where you'd like those to be located.