### PR TITLE
Add tags variable to terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ module "aws_logs" {
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
-| tags | A mapping of tags to assign to the logs bucket. | `map(string)` | `{}` | no |
+| tags | A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ module "aws_logs" {
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
+| tags | A mapping of tags to assign to the logs bucket. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -5,5 +5,5 @@ module "aws_logs" {
   region         = var.region
 
   force_destroy = var.force_destroy
-  tags          = { owner = "user" }
+  tags          = var.tags
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -5,4 +5,5 @@ module "aws_logs" {
   region         = var.region
 
   force_destroy = var.force_destroy
+  tags          = { owner = "user" }
 }

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -9,3 +9,8 @@ variable "region" {
 variable "force_destroy" {
   type = bool
 }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/trussworks/terraform-aws-logs
 
 go 1.14
 
-require github.com/gruntwork-io/terratest v0.27.4
+require (
+	github.com/aws/aws-sdk-go v1.27.1
+	github.com/gruntwork-io/terratest v0.27.4
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -187,12 +187,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/gruntwork-io/gruntwork-cli v0.5.1 h1:mVmVsFubUSLSCO8bGigI63HXzvzkC0uWXzm4dd9pXRg=
 github.com/gruntwork-io/gruntwork-cli v0.5.1/go.mod h1:IBX21bESC1/LGoV7jhXKUnTQTZgQ6dYRsoj/VqxUSZQ=
-github.com/gruntwork-io/terratest v0.26.1 h1:T+R6sxhr4hTkbhOl9EIp/xTJm6070YcM5sCG0tR4xXg=
-github.com/gruntwork-io/terratest v0.26.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
-github.com/gruntwork-io/terratest v0.27.1 h1:cUmpCwK+zmhmSEmjwKiM406uTRBp9UTq0lxNeZmOND8=
-github.com/gruntwork-io/terratest v0.27.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
-github.com/gruntwork-io/terratest v0.27.3 h1:kDTrA+b+OoqDkwLs0A7THgK8WPXyHfuPiZB2XvR5vVU=
-github.com/gruntwork-io/terratest v0.27.3/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/gruntwork-io/terratest v0.27.4 h1:+Pgf3pHRPgVjNv0/MyLWwySmKUcmL+wT6fewu6F4sBE=
 github.com/gruntwork-io/terratest v0.27.4/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/main.tf
+++ b/main.tf
@@ -366,10 +366,12 @@ resource "aws_s3_bucket" "aws_logs" {
     }
   }
 
-  tags = {
-    Name       = var.s3_bucket_name
-    Automation = "Terraform"
-  }
+  tags = merge(
+    var.tags, {
+      Name       = var.s3_bucket_name
+      Automation = "Terraform"
+    }
+  )
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block" {

--- a/test/terraform_aws_logs_test.go
+++ b/test/terraform_aws_logs_test.go
@@ -5,9 +5,14 @@ import (
 	"strings"
 	"testing"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTerraformAwsLogs(t *testing.T) {
@@ -31,4 +36,51 @@ func TestTerraformAwsLogs(t *testing.T) {
 
 	defer terraform.Destroy(t, terraformOptions)
 	terraform.InitAndApply(t, terraformOptions)
+}
+
+func TestTerraformAwsLogsWithConflictingTags(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/simple")
+	testName := fmt.Sprintf("terratest-aws-logs-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
+			"tags": map[string]string{
+				"Name": "darkwing duck",
+				"Test": "true",
+			},
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+
+	s3Client, err := aws.NewS3ClientE(t, awsRegion)
+	require.NoError(t, err)
+
+	params := &s3.GetBucketTaggingInput{
+		Bucket: awssdk.String(testName),
+	}
+
+	taggingOutput, err := s3Client.GetBucketTagging(params)
+	require.NoError(t, err)
+
+	assert.Greater(t, len(taggingOutput.TagSet), 2)
+	for _, tag := range taggingOutput.TagSet {
+		if *tag.Key == "Name" {
+			assert.Equal(t, *tag.Value, testName)
+		}
+		if *tag.Key == "Test" {
+			assert.Equal(t, *tag.Value, "true")
+		}
+	}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,9 @@ variable "nlb_logs_prefixes" {
   default     = ["nlb"]
   type        = list(string)
 }
+
+variable tags {
+  type        = map(string)
+  default     = {}
+  description = "A mapping of tags to assign to the logs bucket."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -144,5 +144,5 @@ variable "nlb_logs_prefixes" {
 variable tags {
   type        = map(string)
   default     = {}
-  description = "A mapping of tags to assign to the logs bucket."
+  description = "A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag."
 }


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/172481131)

This ticket adds a new variable to allow a user of the module to add their own tags to the logs s3 bucket.

This implementation is modeled after [terraform-aws-rds](https://github.com/terraform-aws-modules/terraform-aws-rds/blob/master/variables.tf#L219)