### PR TITLE
Relax version constraints so folks can use this module with 0.14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ module "aws_logs" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
+| terraform | >= 0.13.0 |
 | aws | ~> 3.0 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = "~> 3.0"


### PR DESCRIPTION
Terraform 0.14.x doesn't have syntactical upgrades that require running something like `terraform 0.14upgrade`. So this PR relaxes the versioning constraints so folks on 0.13.x and 0.14.x can keep swimming. 