### PR TITLE
Deprecate Terraform 0.11 and relax version AWS provider version constraints.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         username: $DOCKER_USERNAME
       environment:
       - TEST_RESULTS: /tmp/test-results
-      image: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
+      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
     steps:
     - checkout
     - restore_cache:
@@ -14,19 +14,18 @@ jobs:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
         - go-mod-sources-v1-{{ checksum "go.sum" }}
     - run:
-        command: 'echo ''export PATH=${PATH}:~/go/bin'' >> $BASH_ENV
-
+        command: |
+          echo 'export PATH=${PATH}:~/go/bin' >> $BASH_ENV
           source $BASH_ENV
-
-          '
         name: Adding go binaries to $PATH
     - run: go get github.com/jstemmer/go-junit-report
     - run:
-        command: "temp_role=$(aws sts assume-role \\\n        --role-arn arn:aws:iam::313564602749:role/circleci\
-          \ \\\n        --role-session-name circleci)\nexport AWS_ACCESS_KEY_ID=$(echo\
-          \ $temp_role | jq .Credentials.AccessKeyId | xargs)\nexport AWS_SECRET_ACCESS_KEY=$(echo\
-          \ $temp_role | jq .Credentials.SecretAccessKey | xargs)\nexport AWS_SESSION_TOKEN=$(echo\
-          \ $temp_role | jq .Credentials.SessionToken | xargs)\nmake test\n"
+        command: |
+          temp_role=$(aws sts assume-role --role-arn arn:aws:iam::313564602749:role/circleci --role-session-name circleci)
+          export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+          export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+          export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+          make test
         name: Assume role, run pre-commit and run terratest
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
@@ -38,8 +37,6 @@ jobs:
         - ~/go/pkg/mod
     - store_test_results:
         path: /tmp/test-results/gotest
-references:
-  circleci: trussworks/circleci:6986bb9022e5a83599feb66a7128a2d0fa12732a
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.25.0
+    rev: v0.26.0
     hooks:
       - id: markdownlint
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,9 @@ Logging from the following services is supported for both cases as well as in AW
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to ~> 9.0.0 Submit pull-requests to master branch.
+Terraform 0.13. Pin module version to ~> 10.X Submit pull-requests to master branch.
 
-Terraform 0.12. Pin module version to ~> 8.0.0 . Submit pull-requests to terraform12 branch.
-
-Terraform 0.11. Pin module version to ~> 3.5.0 . Submit pull-requests to terraform011 branch.
+Terraform 0.12. Pin module version to ~> 8.X . Submit pull-requests to terraform12 branch.
 
 ## Usage for a single log bucket storing logs from all services
 
@@ -94,13 +92,13 @@ module "aws_logs" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13.0 |
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/examples/alb/providers.tf
+++ b/examples/alb/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/alb_remote/providers.tf
+++ b/examples/alb_remote/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/cloudtrail/providers.tf
+++ b/examples/cloudtrail/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/combined/providers.tf
+++ b/examples/combined/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-  region  = var.region
-}

--- a/examples/config/providers.tf
+++ b/examples/config/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-  region  = var.region
-}

--- a/examples/elb/providers.tf
+++ b/examples/elb/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/logging_target_bucket/providers.tf
+++ b/examples/logging_target_bucket/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/nlb/providers.tf
+++ b/examples/nlb/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/nlb_remote/providers.tf
+++ b/examples/nlb_remote/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/redshift/providers.tf
+++ b/examples/redshift/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/s3/providers.tf
+++ b/examples/s3/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/examples/simple/providers.tf
+++ b/examples/simple/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  version = "~> 3.0"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
We've already relaxed the version constraints to allow Terraform 0.14 to use this module. This PR will run the terratests on 0.14 and remove support for 0.11. Lastly, this PR cleans up the CircleCI config and updates pre-commit hooks.  

Once merged, I will remove the `terraform011` branch.
