### PR TITLE
Adding support for versioning of logs buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,13 @@ module "aws_logs" {
 | logging\_target\_prefix | Prefix for logs going into the log\_s3\_bucket. | `string` | `"s3/"` | no |
 | nlb\_account | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
 | nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |
+| noncurrent\_version\_retention | Number of days to retain non-current versions of objects if versioning is enabled. | `string` | `30` | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
 | tags | A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag. | `map(string)` | `{}` | no |
+| versioning\_enable | A bool that enables versioning for the log bucket. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ module "aws_logs" {
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | `bool` | `true` | no |
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | elb\_logs\_prefix | S3 prefix for ELB logs. | `string` | `"elb"` | no |
+| enable\_versioning | A bool that enables versioning for the log bucket. | `bool` | `false` | no |
 | force\_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
 | logging\_target\_bucket | S3 Bucket to send S3 logs to. Disables logging if omitted. | `string` | `null` | no |
 | logging\_target\_prefix | Prefix for logs going into the log\_s3\_bucket. | `string` | `"s3/"` | no |
@@ -134,7 +135,6 @@ module "aws_logs" {
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
 | tags | A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag. | `map(string)` | `{}` | no |
-| versioning\_enable | A bool that enables versioning for the log bucket. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/examples/versioning/main.tf
+++ b/examples/versioning/main.tf
@@ -1,0 +1,10 @@
+module "aws_logs" {
+  source = "../../"
+
+  s3_bucket_name = var.test_name
+
+  versioning_enable = true
+
+  force_destroy = var.force_destroy
+  tags          = var.tags
+}

--- a/examples/versioning/main.tf
+++ b/examples/versioning/main.tf
@@ -3,7 +3,7 @@ module "aws_logs" {
 
   s3_bucket_name = var.test_name
 
-  versioning_enable = true
+  enable_versioning = true
 
   force_destroy = var.force_destroy
   tags          = var.tags

--- a/examples/versioning/variables.tf
+++ b/examples/versioning/variables.tf
@@ -1,0 +1,16 @@
+variable "test_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "force_destroy" {
+  type = bool
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -360,7 +360,7 @@ resource "aws_s3_bucket" "aws_logs" {
   force_destroy = var.force_destroy
 
   versioning {
-    enabled = var.versioning_enable
+    enabled = var.enable_versioning
   }
 
   lifecycle_rule {

--- a/main.tf
+++ b/main.tf
@@ -359,6 +359,10 @@ resource "aws_s3_bucket" "aws_logs" {
   policy        = data.aws_iam_policy_document.main.json
   force_destroy = var.force_destroy
 
+  versioning {
+    enabled = var.versioning_enable
+  }
+
   lifecycle_rule {
     id      = "expire_all_logs"
     prefix  = "/*"
@@ -366,6 +370,10 @@ resource "aws_s3_bucket" "aws_logs" {
 
     expiration {
       days = var.s3_log_bucket_retention
+    }
+
+    noncurrent_version_expiration {
+      days = var.noncurrent_version_retention
     }
   }
 

--- a/test/terraform_aws_logs_versioning.go
+++ b/test/terraform_aws_logs_versioning.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+func TestTerraformAwsLogsVersioning(t *testing.T) {
+	t.Parallel()
+
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/versioning")
+	testName := fmt.Sprintf("terratest-aws-logs-%s", strings.ToLower(random.UniqueId()))
+	awsRegion := "us-west-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":        awsRegion,
+			"test_name":     testName,
+			"force_destroy": true,
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -178,7 +178,7 @@ variable "tags" {
   description = "A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag."
 }
 
-variable "versioning_enable" {
+variable "enable_versioning" {
   description = "A bool that enables versioning for the log bucket."
   default     = false
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "s3_log_bucket_retention" {
   type        = string
 }
 
+variable "noncurrent_version_retention" {
+  description = "Number of days to retain non-current versions of objects if versioning is enabled."
+  type        = string
+  default     = 30
+}
+
 variable "s3_bucket_acl" {
   description = "Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list."
   default     = "log-delivery-write"
@@ -170,4 +176,10 @@ variable "tags" {
   type        = map(string)
   default     = {}
   description = "A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag."
+}
+
+variable "versioning_enable" {
+  description = "A bool that enables versioning for the log bucket."
+  default     = false
+  type        = bool
 }


### PR DESCRIPTION
CMS has a requirement to add versioning to S3 buckets, so adding this as an option will give us one less thing to worry about. I set versioning off by default, since that was the previous functionality, and added a lifecycle rule to purge noncurrent versions of objects after a number of days specified in another variable (default 30).