### PR TITLE
Restrict to 3.x of the aws provider in anticipation of breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ module "aws_logs" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0, < 4.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.0"
+    aws = ">= 3.0, < 4.0"
   }
 }


### PR DESCRIPTION
Lots of breaking changes around s3 resources coming in the [4.0 version of the AWS provider](https://github.com/hashicorp/terraform-provider-aws/issues/20433).  This PR prevents us from falling into those breaking changes until we've made the necessary fixes. 