### PR TITLE
Allow GuardDuty to write to AWS logging bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ No modules.
 | <a name="input_allow_cloudwatch"></a> [allow\_cloudwatch](#input\_allow\_cloudwatch) | Allow Cloudwatch service to export logs to bucket. | `bool` | `false` | no |
 | <a name="input_allow_config"></a> [allow\_config](#input\_allow\_config) | Allow Config service to log to bucket. | `bool` | `false` | no |
 | <a name="input_allow_elb"></a> [allow\_elb](#input\_allow\_elb) | Allow ELB service to log to bucket. | `bool` | `false` | no |
+| <a name="input_allow_guardduty"></a> [allow\_guardduty](#input\_allow\_guardduty) | Allow GuardDuty service to log to bucket. | `bool` | `false` | no |
 | <a name="input_allow_nlb"></a> [allow\_nlb](#input\_allow\_nlb) | Allow NLB service to log to bucket. | `bool` | `false` | no |
 | <a name="input_allow_redshift"></a> [allow\_redshift](#input\_allow\_redshift) | Allow Redshift service to log to bucket. | `bool` | `false` | no |
 | <a name="input_cloudtrail_accounts"></a> [cloudtrail\_accounts](#input\_cloudtrail\_accounts) | List of accounts for CloudTrail logs.  By default limits to the current account. | `list(string)` | `[]` | no |
@@ -143,6 +144,7 @@ No modules.
 | <a name="input_enable_mfa_delete"></a> [enable\_mfa\_delete](#input\_enable\_mfa\_delete) | A bool that requires MFA to delete the log bucket. | `bool` | `false` | no |
 | <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | A bool that enables versioning for the log bucket. | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
+| <a name="input_guardduty_logs_prefix"></a> [guardduty\_logs\_prefix](#input\_guardduty\_logs\_prefix) | S3 prefix for AWS GuardDuty logs. | `string` | `"guardduty"` | no |
 | <a name="input_logging_target_bucket"></a> [logging\_target\_bucket](#input\_logging\_target\_bucket) | S3 Bucket to send S3 logs to. Disables logging if omitted. | `string` | `null` | no |
 | <a name="input_logging_target_prefix"></a> [logging\_target\_prefix](#input\_logging\_target\_prefix) | Prefix for logs going into the log\_s3\_bucket. | `string` | `"s3/"` | no |
 | <a name="input_nlb_account"></a> [nlb\_account](#input\_nlb\_account) | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |

--- a/examples/guardduty/main.tf
+++ b/examples/guardduty/main.tf
@@ -1,0 +1,17 @@
+module "aws_logs" {
+  source = "../../"
+
+  s3_bucket_name        = var.test_name
+  allow_guardduty       = true
+  default_allow         = false
+  guardduty_logs_prefix = var.guardduty_logs_prefix
+
+  force_destroy = var.force_destroy
+}
+
+module "guardduty" {
+  source  = "dod-iac/guardduty/aws"
+  version = "~> 1"
+
+  s3_bucket_name = module.logs.aws_logs_bucket
+}

--- a/examples/guardduty/main.tf
+++ b/examples/guardduty/main.tf
@@ -13,5 +13,5 @@ module "guardduty" {
   source  = "dod-iac/guardduty/aws"
   version = "~> 1"
 
-  s3_bucket_name = module.logs.aws_logs_bucket
+  s3_bucket_name = module.aws_logs.aws_logs_bucket
 }

--- a/examples/guardduty/variables.tf
+++ b/examples/guardduty/variables.tf
@@ -1,0 +1,15 @@
+variable "test_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "force_destroy" {
+  type = bool
+}
+
+variable "guardduty_logs_prefix" {
+  type = string
+}

--- a/test/terraform_aws_logs_guardduty_test.go
+++ b/test/terraform_aws_logs_guardduty_test.go
@@ -1,0 +1,63 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+func TestTerraformAwsLogsGuardduty(t *testing.T) {
+	t.Parallel()
+
+	testName := fmt.Sprintf("terratest-aws-logs-%s", strings.ToLower(random.UniqueId()))
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/guardduty")
+	// AWS only supports one guarddutyuration recorder per region.
+	// Each test using aws-guardduty will need to specify a different region.
+	awsRegion := "us-east-2"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":                awsRegion,
+			"test_name":             testName,
+			"force_destroy":         true,
+			"guardduty_logs_prefix": testName,
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}
+
+func TestTerraformAwsLogsGuardDutyRootPrefix(t *testing.T) {
+	t.Parallel()
+
+	testName := fmt.Sprintf("terratest-aws-logs-%s", strings.ToLower(random.UniqueId()))
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/guardduty")
+	// AWS only supports one guarddutyuration recorder per region.
+	// Each test using aws-guardduty will need to specify a different region.
+	awsRegion := "us-east-1"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"region":                awsRegion,
+			"test_name":             testName,
+			"force_destroy":         true,
+			"guardduty_logs_prefix": "",
+		},
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": awsRegion,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "config_logs_prefix" {
   type        = string
 }
 
+variable "guardduty_logs_prefix" {
+  description = "S3 prefix for AWS GuardDuty logs."
+  default     = "guardduty"
+  type        = string
+}
+
 # Service Switches
 variable "default_allow" {
   description = "Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write."
@@ -96,6 +102,12 @@ variable "allow_config" {
 
 variable "allow_elb" {
   description = "Allow ELB service to log to bucket."
+  default     = false
+  type        = bool
+}
+
+variable "allow_guardduty" {
+  description = "Allow GuardDuty service to log to bucket."
   default     = false
   type        = bool
 }


### PR DESCRIPTION
Replaces #54 and #63 

@pjdufour-dds I'm not entirely clear on why #63 was closed by @dynamike by looking at the PR comments. However, we still use this code and I'd love to have it implemented. I've gotten everything up to date and it appears to work fine with our infra. I'm happy to take over taking this forward.