### PR TITLE
Updating for aws v4 provider (and a little cleanup of the pre-commit hooks)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-json
@@ -11,18 +11,18 @@ repos:
           - --autofix
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
+  - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.28.1
     hooks:
       - id: markdownlint
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.50.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
-  - repo: git://github.com/golangci/golangci-lint
+  - repo: https://github.com/golangci/golangci-lint
     rev: v1.41.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ No modules.
 | <a name="input_enable_mfa_delete"></a> [enable\_mfa\_delete](#input\_enable\_mfa\_delete) | A bool that requires MFA to delete the log bucket. | `bool` | `false` | no |
 | <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | A bool that enables versioning for the log bucket. | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
-| <a name="input_logging_target_bucket"></a> [logging\_target\_bucket](#input\_logging\_target\_bucket) | S3 Bucket to send S3 logs to. Disables logging if omitted. | `string` | `null` | no |
+| <a name="input_logging_target_bucket"></a> [logging\_target\_bucket](#input\_logging\_target\_bucket) | S3 Bucket to send S3 logs to. Disables logging if omitted. | `string` | `""` | no |
 | <a name="input_logging_target_prefix"></a> [logging\_target\_prefix](#input\_logging\_target\_prefix) | Prefix for logs going into the log\_s3\_bucket. | `string` | `"s3/"` | no |
 | <a name="input_nlb_account"></a> [nlb\_account](#input\_nlb\_account) | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
 | <a name="input_nlb_logs_prefixes"></a> [nlb\_logs\_prefixes](#input\_nlb\_logs\_prefixes) | S3 key prefixes for NLB logs. | `list(string)` | <pre>[<br>  "nlb"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ No modules.
 | [aws_s3_bucket_acl.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_lifecycle_configuration.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_policy.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ module "aws_logs" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, < 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 
 ## Modules
 
@@ -109,7 +109,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_lifecycle_configuration.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/examples/combined/main.tf
+++ b/examples/combined/main.tf
@@ -99,13 +99,19 @@ resource "aws_redshift_subnet_group" "test_redshift" {
 
 resource "aws_s3_bucket" "log_source_bucket" {
   bucket        = "${var.test_name}-source"
-  acl           = "private"
   force_destroy = var.force_destroy
+}
 
-  logging {
-    target_bucket = module.aws_logs.aws_logs_bucket
-    target_prefix = "log/"
-  }
+resource "aws_s3_bucket_acl" "log_source_bucket" {
+  bucket = aws_s3_bucket.log_source_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_logging" "log_source_bucket" {
+  bucket = aws_s3_bucket.log_source_bucket.id
+
+  target_bucket = module.aws_logs.aws_logs_bucket
+  target_prefix = "log/"
 }
 
 module "vpc" {

--- a/examples/logging_target_bucket/main.tf
+++ b/examples/logging_target_bucket/main.tf
@@ -1,3 +1,7 @@
+locals {
+  log_bucket_name = "${var.test_name}-logs"
+}
+
 module "aws_logs" {
   source = "../../"
 
@@ -5,16 +9,20 @@ module "aws_logs" {
 
   default_allow = false
 
-  logging_target_bucket = module.aws_logs_logs.aws_logs_bucket
+  logging_target_bucket = local.log_bucket_name
   logging_target_prefix = var.s3_logs_prefix
 
   force_destroy = var.force_destroy
+
+  depends_on = [
+    module.aws_logs_logs
+  ]
 }
 
 module "aws_logs_logs" {
   source = "../../"
 
-  s3_bucket_name = "${var.test_name}-logs"
+  s3_bucket_name = local.log_bucket_name
 
   default_allow = false
 

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -10,10 +10,16 @@ module "aws_logs" {
 
 resource "aws_s3_bucket" "log_source_bucket" {
   bucket = "${var.test_name}-source"
-  acl    = "private"
+}
 
-  logging {
-    target_bucket = module.aws_logs.aws_logs_bucket
-    target_prefix = var.s3_logs_prefix
-  }
+resource "aws_s3_bucket_acl" "log_source_bucket" {
+  bucket = aws_s3_bucket.log_source_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_logging" "log_source_bucket" {
+  bucket = aws_s3_bucket.log_source_bucket.id
+
+  target_bucket = module.aws_logs.aws_logs_bucket
+  target_prefix = var.s3_logs_prefix
 }

--- a/main.tf
+++ b/main.tf
@@ -416,7 +416,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "aws_logs" {
 }
 
 resource "aws_s3_bucket_logging" "aws_logs" {
-  count = var.logging_target_bucket != null ? 1 : 0
+  count = var.logging_target_bucket != "" ? 1 : 0
 
   bucket = aws_s3_bucket.aws_logs.id
 

--- a/main.tf
+++ b/main.tf
@@ -363,7 +363,6 @@ data "aws_iam_policy_document" "main" {
 
 resource "aws_s3_bucket" "aws_logs" {
   bucket        = var.s3_bucket_name
-  policy        = data.aws_iam_policy_document.main.json
   force_destroy = var.force_destroy
 
   tags = merge(
@@ -371,6 +370,11 @@ resource "aws_s3_bucket" "aws_logs" {
       Name = var.s3_bucket_name
     }
   )
+}
+
+resource "aws_s3_bucket_policy" "aws_logs" {
+  bucket = aws_s3_bucket.aws_logs.id
+  policy = data.aws_iam_policy_document.main.json
 }
 
 resource "aws_s3_bucket_acl" "aws_logs" {

--- a/main.tf
+++ b/main.tf
@@ -374,7 +374,7 @@ resource "aws_s3_bucket" "aws_logs" {
 }
 
 resource "aws_s3_bucket_acl" "aws_logs" {
-  bucket = aws_s3_bucket.aws_logs
+  bucket = aws_s3_bucket.aws_logs.id
   acl    = var.s3_bucket_acl
 }
 
@@ -382,7 +382,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
   bucket = aws_s3_bucket.aws_logs.id
 
   rule {
-    id = "expire_all_logs"
+    id     = "expire_all_logs"
+    status = "Enabled"
 
     filter {
       prefix = "/*"
@@ -393,7 +394,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
     }
 
     noncurrent_version_expiration {
-      days = var.noncurrent_version_retention
+      noncurrent_days = var.noncurrent_version_retention
     }
   }
 
@@ -422,8 +423,8 @@ resource "aws_s3_bucket_logging" "aws_logs" {
 resource "aws_s3_bucket_versioning" "aws_logs" {
   bucket = aws_s3_bucket.aws_logs.id
   versioning_configuration {
-    enabled    = var.enable_versioning
-    mfa_delete = var.enable_mfa_delete
+    status     = var.enable_versioning ? "Enabled" : "Disabled"
+    mfa_delete = var.enable_mfa_delete ? "Enabled" : "Disabled"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -162,7 +162,7 @@ variable "cloudtrail_org_id" {
 
 variable "logging_target_bucket" {
   description = "S3 Bucket to send S3 logs to. Disables logging if omitted."
-  default     = null
+  default     = ""
   type        = string
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.0, < 4.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
Saw that this wasn't updated to v4 of the AWS provider, so I've gone through and moved all the blocks out of the `aws_s3_bucket` resource and into the various individual s3 config pieces. I believe the upgrade process should be pretty transparent.

I've tested this with a repo running v3 and it works with no warnings.