### PR TITLE
address conflicting iam role and cloudtrail names

### DIFF
--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -13,7 +13,9 @@ module "aws_cloudtrail" {
   source  = "trussworks/cloudtrail/aws"
   version = "~> 2"
 
+  iam_role_name             = "cloudtrail-cloudwatch-logs-role-${var.test_name}"
   s3_bucket_name            = module.aws_logs.aws_logs_bucket
-  cloudwatch_log_group_name = var.test_name
   s3_key_prefix             = var.cloudtrail_logs_prefix
+  cloudwatch_log_group_name = var.test_name
+  trail_name                = "cloudtrail-${var.test_name}"
 }

--- a/examples/combined/main.tf
+++ b/examples/combined/main.tf
@@ -24,9 +24,11 @@ module "aws_cloudtrail" {
   source  = "trussworks/cloudtrail/aws"
   version = "~> 2"
 
+  iam_role_name             = "cloudtrail-cloudwatch-logs-role-${var.test_name}"
   s3_bucket_name            = module.aws_logs.aws_logs_bucket
   s3_key_prefix             = "cloudtrail"
   cloudwatch_log_group_name = var.test_name
+  trail_name                = "cloudtrail-${var.test_name}"
 }
 
 module "config" {


### PR DESCRIPTION
This addresses a couple issues where name conflicts can occur during CI tests:

```
╷
│ Error: Error creating CloudTrail: TrailAlreadyExistsException: Trail cloudtrail already exists for customer: 313564602749
│ 
│   with module.aws_cloudtrail.aws_cloudtrail.main,
│   on .terraform/modules/aws_cloudtrail/main.tf line 246, in resource "aws_cloudtrail" "main":
│  246: resource "aws_cloudtrail" "main" {
│ 
╵}
```

or

```
│ Error: failed creating IAM Role (cloudtrail-cloudwatch-logs-role): EntityAlreadyExists: Role with name cloudtrail-cloudwatch-logs-role already exists.
│ 	status code: 409, request id: a4d3a784-4eb8-467e-8bd7-8a2a29fc0632
│ 
│   with module.aws_cloudtrail.aws_iam_role.cloudtrail_cloudwatch_role,
│   on .terraform/modules/aws_cloudtrail/main.tf line 32, in resource "aws_iam_role" "cloudtrail_cloudwatch_role":
│   32: resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
│ 
╵
```

However, there are still issues like this, which are due to hardcoded names: https://github.com/trussworks/terraform-aws-cloudtrail/blob/24caf740164b9a12e54c50c2dc31c93dfdf46155/main.tf#L61

```
│ Error: error creating IAM Policy cloudtrail-cloudwatch-logs-policy: EntityAlreadyExists: A policy called cloudtrail-cloudwatch-logs-policy already exists. Duplicate names are not allowed.
│ 	status code: 409, request id: ...
│ 
│   with module.aws_cloudtrail.aws_iam_policy.cloudtrail_cloudwatch_logs,
│   on .terraform/modules/aws_cloudtrail/main.tf line 60, in resource "aws_iam_policy" "cloudtrail_cloudwatch_logs":
│   60: resource "aws_iam_policy" "cloudtrail_cloudwatch_logs" {
│ 
```

If those continue to be an issue, we may need to add the option to configure that policy name in the upstream repository. Alternatively, we could stop running CI tests in parallel, but then testing will take even longer.