### PR TITLE
add backwards compatibility to aws_s3_bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -370,6 +370,13 @@ resource "aws_s3_bucket" "aws_logs" {
       Name = var.s3_bucket_name
     }
   )
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule,
+      server_side_encryption_configuration
+    ]
+  }
 }
 
 resource "aws_s3_bucket_policy" "aws_logs" {


### PR DESCRIPTION
Ignore changes to the `lifecycle_rule` and `server_side_encryption_configuration` keys in the `aws_s3_bucket` resource to allow for upgrades to 4.x of the AWS provider.

This is based off the recommendations here:
- [aws_s3_bucket_lifecycle_configuration  usage notes](https://github.com/hashicorp/terraform-provider-aws/blob/v3.75.1/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown#usage-notes)
- [aws_s3_bucket_server_side_encryption_configuration  usage notes](https://github.com/hashicorp/terraform-provider-aws/blob/v3.75.1/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown#usage-notes)