### PR TITLE
avoid policy name conflicts in ci

### DIFF
--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -11,11 +11,12 @@ module "aws_logs" {
 
 module "aws_cloudtrail" {
   source  = "trussworks/cloudtrail/aws"
-  version = "~> 2"
+  version = "~> 4"
 
   iam_role_name             = "cloudtrail-cloudwatch-logs-role-${var.test_name}"
   s3_bucket_name            = module.aws_logs.aws_logs_bucket
   s3_key_prefix             = var.cloudtrail_logs_prefix
   cloudwatch_log_group_name = var.test_name
   trail_name                = "cloudtrail-${var.test_name}"
+  iam_policy_name           = "cloudtrail-cloudwatch-logs-policy-${var.test_name}"
 }

--- a/examples/combined/main.tf
+++ b/examples/combined/main.tf
@@ -22,13 +22,14 @@ resource "aws_lb" "test_alb" {
 
 module "aws_cloudtrail" {
   source  = "trussworks/cloudtrail/aws"
-  version = "~> 2"
+  version = "~> 4"
 
   iam_role_name             = "cloudtrail-cloudwatch-logs-role-${var.test_name}"
   s3_bucket_name            = module.aws_logs.aws_logs_bucket
   s3_key_prefix             = "cloudtrail"
   cloudwatch_log_group_name = var.test_name
   trail_name                = "cloudtrail-${var.test_name}"
+  iam_policy_name           = "cloudtrail-cloudwatch-logs-policy-${var.test_name}"
 }
 
 module "config" {


### PR DESCRIPTION
This is a follow-up to the remaining issue from https://github.com/trussworks/terraform-aws-logs/pull/269

It addresses name conflicts with the IAM policy name stood up by the cloudtrail module, such as this:

```
│ Error: error creating IAM Policy cloudtrail-cloudwatch-logs-policy: EntityAlreadyExists: A policy called cloudtrail-cloudwatch-logs-policy already exists. Duplicate names are not allowed.
│ 	status code: 409, request id: ...
│ 
│   with module.aws_cloudtrail.aws_iam_policy.cloudtrail_cloudwatch_logs,
│   on .terraform/modules/aws_cloudtrail/main.tf line 60, in resource "aws_iam_policy" "cloudtrail_cloudwatch_logs":
│   60: resource "aws_iam_policy" "cloudtrail_cloudwatch_logs" {
│ 
```