### PR TITLE
Remove filter `/*` as it's redundant and invalid

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -419,9 +419,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
     id     = "expire_all_logs"
     status = "Enabled"
 
-    filter {
-      prefix = "/*"
-    }
+    filter {}
 
     expiration {
       days = var.s3_log_bucket_retention


### PR DESCRIPTION
Remove filter `/*` from lifecycle rules as it's not working with subdirectory approach to the logs (i.e. if we want alb logs under `alb` path etc.).