### PR TITLE
NT: adds arn as output and custom bucket policy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | aws\_logs\_bucket | ID of the S3 bucket containing AWS logs. |
+| bucket\_arn | ARN of the S3 logs bucket |
 | configs\_logs\_path | S3 path for Config logs. |
 | elb\_logs\_path | S3 path for ELB logs. |
 | redshift\_logs\_path | S3 path for RedShift logs. |

--- a/examples/custom_bucket_policy/main.tf
+++ b/examples/custom_bucket_policy/main.tf
@@ -1,0 +1,37 @@
+module "aws_logs" {
+  source = "../../"
+
+  s3_bucket_name = var.test_name
+
+  force_destroy = var.force_destroy
+  tags          = var.tags
+}
+
+data "aws_iam_policy_document" "updated_logs_bucket_policy" {
+  source_policy_documents = [module.aws_logs.s3_bucket_policy.json]
+  statement {
+    sid     = "Allow vpc endpoint"
+    actions = ["s3:*"]
+    effect  = "Allow"
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpce"
+      values   = ["vpce-0123567"]
+    }
+
+    resources = [
+      module.aws_logs.bucket_arn,
+      "${module.aws_logs.bucket_arn}/*"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+
+}
+resource "aws_s3_bucket_policy" "logs_updated_bucket_policy" {
+  bucket = module.logs.aws_logs_bucket
+  policy = data.updated_logs_bucket_policy.json
+}

--- a/examples/custom_bucket_policy/variables.tf
+++ b/examples/custom_bucket_policy/variables.tf
@@ -1,0 +1,16 @@
+variable "test_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "force_destroy" {
+  type = bool
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "s3_bucket_policy" {
   description = "S3 bucket policy"
   value       = data.aws_iam_policy_document.main
 }
+
+output "bucket_arn" {
+  description = "ARN of the S3 logs bucket"
+  value       = aws_s3_bucket.aws_logs.arn
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- adds the bucket arn to output
- adds example for updating/using a custom bucket policy
