### PR TITLE
removes the lifecycle ignore rules put in place for aws provider v4 upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -378,36 +378,6 @@ resource "aws_s3_bucket" "aws_logs" {
       Name = var.s3_bucket_name
     }
   )
-
-  lifecycle {
-    # These lifecycle ignore_changes rules exist to permit a smooth upgrade
-    # path from version 3.x of the AWS provider to version 4.x
-    ignore_changes = [
-      # While no special usage instructions are documented for needing this
-      # ignore_changes rule, changes are still detected during the upgrade
-      # process, so this serves to avoid drift detection since the
-      # aws_s3_bucket_policy will be used instead.
-      policy,
-
-      # While no special usage instructions are documented for needing this
-      # ignore_changes rule, this should avoid drift detection if conflicts
-      # with the aws_s3_bucket_versioning exist.
-      versioning,
-
-      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_acl#usage-notes
-      acl,
-      grant,
-
-      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_lifecycle_configuration#usage-notes
-      lifecycle_rule,
-
-      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_logging#usage-notes
-      logging,
-
-      # https://registry.terraform.io/providers/hashicorp%20%20/aws/3.75.1/docs/resources/s3_bucket_server_side_encryption_configuration#usage-notes
-      server_side_encryption_configuration,
-    ]
-  }
 }
 
 resource "aws_s3_bucket_policy" "aws_logs" {


### PR DESCRIPTION
Allows users to change those attributes again now that the v4 upgrade has been out a while