### PR TITLE
Update the module based on AWS changes to S3 bucket default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ No modules.
 | noncurrent\_version\_retention | Number of days to retain non-current versions of objects if versioning is enabled. | `string` | `30` | no |
 | object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
-| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
+| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
 | s3\_logs\_prefix | S3 prefix for S3 access logs. | `string` | `"s3"` | no |

--- a/README.md
+++ b/README.md
@@ -131,13 +131,14 @@ No modules.
 | allow\_elb | Allow ELB service to log to bucket. | `bool` | `false` | no |
 | allow\_nlb | Allow NLB service to log to bucket. | `bool` | `false` | no |
 | allow\_redshift | Allow Redshift service to log to bucket. | `bool` | `false` | no |
+| allow\_s3 | Allow S3 service to log to bucket. | `bool` | `false` | no |
 | cloudtrail\_accounts | List of accounts for CloudTrail logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | `string` | `"cloudtrail"` | no |
 | cloudtrail\_org\_id | AWS Organization ID for CloudTrail. | `string` | `""` | no |
 | cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | `string` | `"cloudwatch"` | no |
 | config\_accounts | List of accounts for Config logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | config\_logs\_prefix | S3 prefix for AWS Config logs. | `string` | `"config"` | no |
-| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `false` | no |
+| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `true` | no |
 | create\_public\_access\_block | Whether to create a public\_access\_block restricting public access to the bucket. | `bool` | `true` | no |
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | `bool` | `true` | no |
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
@@ -155,6 +156,7 @@ No modules.
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
 | s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
+| s3\_logs\_prefix | S3 prefix for S3 access logs. | `string` | `"s3"` | no |
 | tags | A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag. | `map(string)` | `{}` | no |
 | versioning\_status | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ No modules.
 | [aws_s3_bucket_acl.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_lifecycle_configuration.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_ownership_controls.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.aws_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
@@ -136,6 +137,7 @@ No modules.
 | cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | `string` | `"cloudwatch"` | no |
 | config\_accounts | List of accounts for Config logs.  By default limits to the current account. | `list(string)` | `[]` | no |
 | config\_logs\_prefix | S3 prefix for AWS Config logs. | `string` | `"config"` | no |
+| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `false` | no |
 | create\_public\_access\_block | Whether to create a public\_access\_block restricting public access to the bucket. | `bool` | `true` | no |
 | default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | `bool` | `true` | no |
 | elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
@@ -148,6 +150,7 @@ No modules.
 | nlb\_account | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
 | nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | ```[ "nlb" ]``` | no |
 | noncurrent\_version\_retention | Number of days to retain non-current versions of objects if versioning is enabled. | `string` | `30` | no |
+| object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
 | redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
 | s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `"log-delivery-write"` | no |
 | s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -196,12 +196,17 @@ New variables:
 
 Steps for updating existing buckets managed by this module:
 
-- **Option 1: Disable ACLs.** In order to update an existing log bucket to use
-  the new AWS recommended defaults, use this module's default values for the new
-  input variables. Using those settings will disable S3 access control lists for
-  the bucket and set object ownership to `BucketOwnerEnforced`. Update the log
-  bucket policy to grant `s3:PutObject` permission to the logging service
-  principal (`logging.s3.amazonaws.com`).
+- **Option 1: Disable ACLs.** This module's default values for
+  `control_object_ownership`, `object_ownership`, and `s3_bucket_acl` follow the
+  new AWS recommended best practice. For a new S3 bucket, using those settings
+  will disable S3 access control lists for the bucket and set object ownership
+  to `BucketOwnerEnforced`. For an existing bucket that is used to store s3
+  server access logs, the bucket ACL permissions for the S3 log delivery group
+  must be migrated to the bucket policy. The changes must be applied
+  in multiple steps.
+
+Step 1: Update the log bucket policy to grant `s3:PutObject` permission to the
+logging service principal (`logging.s3.amazonaws.com`).
 
   Example:
 
@@ -217,6 +222,10 @@ Steps for updating existing buckets managed by this module:
     resources = ["BUCKET_ARN_PLACEHOLDER/LOGGING_PREFIX_PLACEHOLDER/*"]
   }
 ```
+
+Step 2: Change `s3_bucket_acl` to `private`.
+
+Step 3: Change `object_ownership` to `BucketOwnerEnforced`.
 
 - **Option 2: Continue using ACLs.** To continue using ACLs, set `s3_bucket_acl`
   to `"log-delivery-write"` and set `object_ownership` to `ObjectWriter` or

--- a/main.tf
+++ b/main.tf
@@ -392,8 +392,26 @@ resource "aws_s3_bucket_policy" "aws_logs" {
 }
 
 resource "aws_s3_bucket_acl" "aws_logs" {
+  bucket     = aws_s3_bucket.aws_logs.id
+  acl        = var.s3_bucket_acl
+  depends_on = [aws_s3_bucket_ownership_controls.aws_logs]
+}
+
+resource "aws_s3_bucket_ownership_controls" "aws_logs" {
+  count = var.control_object_ownership ? 1 : 0
+
   bucket = aws_s3_bucket.aws_logs.id
-  acl    = var.s3_bucket_acl
+
+  rule {
+    object_ownership = var.object_ownership
+  }
+
+  # This `depends_on` is to prevent "A conflicting conditional operation is currently in progress against this resource."
+  depends_on = [
+    aws_s3_bucket_policy.aws_logs,
+    aws_s3_bucket_public_access_block.public_access_block,
+    aws_s3_bucket.aws_logs
+  ]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {

--- a/main.tf
+++ b/main.tf
@@ -416,6 +416,7 @@ resource "aws_s3_bucket_policy" "aws_logs" {
 }
 
 resource "aws_s3_bucket_acl" "aws_logs" {
+  count      = var.s3_bucket_acl != null ? 1 : 0
   bucket     = aws_s3_bucket.aws_logs.id
   acl        = var.s3_bucket_acl
   depends_on = [aws_s3_bucket_ownership_controls.aws_logs]

--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,7 @@ locals {
   # doesn't support logging to multiple accounts
   s3_effect = var.default_allow || var.allow_s3 ? "Allow" : "Deny"
 
-  s3_resources = "${local.bucket_arn}/${var.s3_logs_prefix}/*"
+  s3_resources = ["${local.bucket_arn}/${var.s3_logs_prefix}/*"]
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -406,7 +406,6 @@ resource "aws_s3_bucket_ownership_controls" "aws_logs" {
     object_ownership = var.object_ownership
   }
 
-  # This `depends_on` is to prevent "A conflicting conditional operation is currently in progress against this resource."
   depends_on = [
     aws_s3_bucket_policy.aws_logs,
     aws_s3_bucket_public_access_block.public_access_block,

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "s3_bucket_acl" {
   type        = string
 }
 
+variable "s3_logs_prefix" {
+  description = "S3 prefix for S3 access logs."
+  default     = "s3"
+  type        = string
+}
+
 variable "elb_logs_prefix" {
   description = "S3 prefix for ELB logs."
   default     = "elb"
@@ -102,6 +108,12 @@ variable "allow_elb" {
 
 variable "allow_redshift" {
   description = "Allow Redshift service to log to bucket."
+  default     = false
+  type        = bool
+}
+
+variable "allow_s3" {
+  description = "Allow S3 service to log to bucket."
   default     = false
   type        = bool
 }
@@ -203,7 +215,7 @@ variable "enable_mfa_delete" {
 variable "control_object_ownership" {
   description = "Whether to manage S3 Bucket Ownership Controls on this bucket."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "object_ownership" {

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,15 @@ variable "enable_mfa_delete" {
   default     = false
   type        = bool
 }
+
+variable "control_object_ownership" {
+  description = "Whether to manage S3 Bucket Ownership Controls on this bucket."
+  type        = bool
+  default     = false
+}
+
+variable "object_ownership" {
+  description = "Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter."
+  type        = string
+  default     = "BucketOwnerEnforced"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "noncurrent_version_retention" {
 
 variable "s3_bucket_acl" {
   description = "Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list."
-  default     = "log-delivery-write"
+  default     = null
   type        = string
 }
 


### PR DESCRIPTION
Resolves #307 

Updates the module to account for changes made by AWS in April 2023 to the default security settings of new S3 buckets.

https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

See the proposed changes in the README `Upgrade Paths` section for more details about the module changes.

If approved, the plan is to release this as a major version update.
