### PR TITLE
Removes the redshift service account and switches to service principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ No modules.
 | [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_redshift_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/redshift_service_account) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs


### PR DESCRIPTION
In response to the following warning:
```
│ Warning: Deprecated Resource
│
│   with module.logs.data.aws_redshift_service_account.main,
│   on .terraform/modules/logs/main.tf line 8, in data "aws_redshift_service_account" "main":
│    8: data "aws_redshift_service_account" "main" {
│
│ The aws_redshift_service_account data source has been deprecated and will be removed in a future version. Use a service principal name instead of AWS
│ account ID in any relevant IAM policy.
```