### PR TITLE
feat: Support passing KMS key to bucket encryption configuration

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   validate-tf:
-    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@3cab03ab95045711da37ad6d63a93c666fc22398 # v0.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .terraform
+.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfstate.*.backup
-.envrc.local
+.envrc*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,0 @@
-linters:
-  enable:
-     - gosec
-     - golint
-     - gofmt
-     - goimports

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -4,5 +4,6 @@
   "first-line-h1": false,
   "line_length": false,
   "no-multiple-blanks": false,
-  "no-inline-html": false
+  "no-inline-html": false,
+  "no-alt-text": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -14,27 +14,17 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
-    hooks:
-      - id: mdformat
-        additional_dependencies:
-          - mdformat-gfm
-          - mdformat-toc
-        # mdformat fights with terraform_docs
-        exclude: README.m(ark)?d(own)?
-
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
 
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "v0.19.0"
     hooks:
-      - id: shell-lint
+      - id: terraform-docs-system
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.96.3
     hooks:
       - id: terraform_fmt

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,35 @@
+version: ">= 0.19.0, < 1.0.0"
+
 settings:
   html: false
   anchor: false
+  escape: false
+  lockfile: false
+  hide-empty: true
 formatter: "markdown table"
+
+sort:
+  enabled: true
+  by: required
+
+sections:
+  show:
+    - requirements
+    - providers
+    - modules
+    - data-sources
+    - resources
+    - inputs
+    - outputs
+
+recursive:
+  enabled: false
+  include-main: false
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -94,10 +94,6 @@ module "aws_logs" {
 |------|---------|
 | aws | >= 3.75.0 |
 
-## Modules
-
-No modules.
-
 ## Resources
 
 | Name | Type |
@@ -121,54 +117,56 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alb\_account | Account for ALB logs.  By default limits to the current account. | `string` | `""` | no |
-| alb\_logs\_prefixes | S3 key prefixes for ALB logs. | `list(string)` | ```[ "alb" ]``` | no |
-| allow\_alb | Allow ALB service to log to bucket. | `bool` | `false` | no |
-| allow\_cloudtrail | Allow Cloudtrail service to log to bucket. | `bool` | `false` | no |
-| allow\_cloudwatch | Allow Cloudwatch service to export logs to bucket. | `bool` | `false` | no |
-| allow\_config | Allow Config service to log to bucket. | `bool` | `false` | no |
-| allow\_elb | Allow ELB service to log to bucket. | `bool` | `false` | no |
-| allow\_nlb | Allow NLB service to log to bucket. | `bool` | `false` | no |
-| allow\_redshift | Allow Redshift service to log to bucket. | `bool` | `false` | no |
-| allow\_s3 | Allow S3 service to log to bucket. | `bool` | `false` | no |
-| cloudtrail\_accounts | List of accounts for CloudTrail logs.  By default limits to the current account. | `list(string)` | `[]` | no |
-| cloudtrail\_logs\_prefix | S3 prefix for CloudTrail logs. | `string` | `"cloudtrail"` | no |
-| cloudtrail\_org\_id | AWS Organization ID for CloudTrail. | `string` | `""` | no |
-| cloudwatch\_logs\_prefix | S3 prefix for CloudWatch log exports. | `string` | `"cloudwatch"` | no |
-| config\_accounts | List of accounts for Config logs.  By default limits to the current account. | `list(string)` | `[]` | no |
-| config\_logs\_prefix | S3 prefix for AWS Config logs. | `string` | `"config"` | no |
-| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `true` | no |
-| create\_public\_access\_block | Whether to create a public\_access\_block restricting public access to the bucket. | `bool` | `true` | no |
-| default\_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | `bool` | `true` | no |
-| elb\_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
-| elb\_logs\_prefix | S3 prefix for ELB logs. | `string` | `"elb"` | no |
-| enable\_mfa\_delete | A bool that requires MFA to delete the log bucket. | `bool` | `false` | no |
-| enable\_s3\_log\_bucket\_lifecycle\_rule | Whether the lifecycle rule for the log bucket is enabled. | `bool` | `true` | no |
-| force\_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
-| logging\_target\_bucket | S3 Bucket to send S3 logs to. Disables logging if omitted. | `string` | `""` | no |
-| logging\_target\_prefix | Prefix for logs going into the log\_s3\_bucket. | `string` | `"s3/"` | no |
-| nlb\_account | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
-| nlb\_logs\_prefixes | S3 key prefixes for NLB logs. | `list(string)` | ```[ "nlb" ]``` | no |
-| noncurrent\_version\_retention | Number of days to retain non-current versions of objects if versioning is enabled. | `string` | `30` | no |
-| object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
-| redshift\_logs\_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
-| s3\_bucket\_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
-| s3\_bucket\_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
-| s3\_log\_bucket\_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
-| s3\_logs\_prefix | S3 prefix for S3 access logs. | `string` | `"s3"` | no |
+| s3_bucket_name | S3 bucket to store AWS logs in. | `string` | n/a | yes |
+| alb_account | Account for ALB logs.  By default limits to the current account. | `string` | `""` | no |
+| alb_logs_prefixes | S3 key prefixes for ALB logs. | `list(string)` | ```[ "alb" ]``` | no |
+| allow_alb | Allow ALB service to log to bucket. | `bool` | `false` | no |
+| allow_cloudtrail | Allow Cloudtrail service to log to bucket. | `bool` | `false` | no |
+| allow_cloudwatch | Allow Cloudwatch service to export logs to bucket. | `bool` | `false` | no |
+| allow_config | Allow Config service to log to bucket. | `bool` | `false` | no |
+| allow_elb | Allow ELB service to log to bucket. | `bool` | `false` | no |
+| allow_nlb | Allow NLB service to log to bucket. | `bool` | `false` | no |
+| allow_redshift | Allow Redshift service to log to bucket. | `bool` | `false` | no |
+| allow_s3 | Allow S3 service to log to bucket. | `bool` | `false` | no |
+| bucket_key_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
+| cloudtrail_accounts | List of accounts for CloudTrail logs.  By default limits to the current account. | `list(string)` | `[]` | no |
+| cloudtrail_logs_prefix | S3 prefix for CloudTrail logs. | `string` | `"cloudtrail"` | no |
+| cloudtrail_org_id | AWS Organization ID for CloudTrail. | `string` | `""` | no |
+| cloudwatch_logs_prefix | S3 prefix for CloudWatch log exports. | `string` | `"cloudwatch"` | no |
+| config_accounts | List of accounts for Config logs.  By default limits to the current account. | `list(string)` | `[]` | no |
+| config_logs_prefix | S3 prefix for AWS Config logs. | `string` | `"config"` | no |
+| control_object_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `true` | no |
+| create_public_access_block | Whether to create a public_access_block restricting public access to the bucket. | `bool` | `true` | no |
+| default_allow | Whether all services included in this module should be allowed to write to the bucket by default. Alternatively select individual services. It's recommended to use the default bucket ACL of log-delivery-write. | `bool` | `true` | no |
+| elb_accounts | List of accounts for ELB logs.  By default limits to the current account. | `list(string)` | `[]` | no |
+| elb_logs_prefix | S3 prefix for ELB logs. | `list(string)` | ```[ "elb" ]``` | no |
+| enable_mfa_delete | A bool that requires MFA to delete the log bucket. | `bool` | `false` | no |
+| enable_s3_log_bucket_lifecycle_rule | Whether the lifecycle rule for the log bucket is enabled. | `bool` | `true` | no |
+| force_destroy | A bool that indicates all objects (including any locked objects) should be deleted from the bucket so the bucket can be destroyed without error. | `bool` | `false` | no |
+| kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. If blank, bucket encryption configuration defaults to AES256. | `string` | `""` | no |
+| logging_target_bucket | S3 Bucket to send S3 logs to. Disables logging if omitted. | `string` | `""` | no |
+| logging_target_prefix | Prefix for logs going into the log_s3_bucket. | `string` | `"s3/"` | no |
+| nlb_account | Account for NLB logs.  By default limits to the current account. | `string` | `""` | no |
+| nlb_logs_prefixes | S3 key prefixes for NLB logs. | `list(string)` | ```[ "nlb" ]``` | no |
+| noncurrent_version_retention | Number of days to retain non-current versions of objects if versioning is enabled. | `string` | `30` | no |
+| object_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. | `string` | `"BucketOwnerEnforced"` | no |
+| redshift_logs_prefix | S3 prefix for RedShift logs. | `string` | `"redshift"` | no |
+| s3_bucket_acl | Set bucket ACL per [AWS S3 Canned ACL](<https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl>) list. | `string` | `null` | no |
+| s3_log_bucket_retention | Number of days to keep AWS logs around. | `string` | `90` | no |
+| s3_logs_prefix | S3 prefix for S3 access logs. | `string` | `"s3"` | no |
 | tags | A mapping of tags to assign to the logs bucket. Please note that tags with a conflicting key will not override the original tag. | `map(string)` | `{}` | no |
-| versioning\_status | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
+| versioning_status | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| aws\_logs\_bucket | ID of the S3 bucket containing AWS logs. |
-| bucket\_arn | ARN of the S3 logs bucket |
-| configs\_logs\_path | S3 path for Config logs. |
-| elb\_logs\_path | S3 path for ELB logs. |
-| redshift\_logs\_path | S3 path for RedShift logs. |
-| s3\_bucket\_policy | S3 bucket policy |
+| aws_logs_bucket | ID of the S3 bucket containing AWS logs. |
+| bucket_arn | ARN of the S3 logs bucket |
+| configs_logs_path | S3 path for Config logs. |
+| elb_logs_path | S3 path for ELB logs. |
+| redshift_logs_path | S3 path for RedShift logs. |
+| s3_bucket_policy | S3 bucket policy |
 <!-- END_TF_DOCS -->
 
 ## Upgrade Paths

--- a/examples/logging_target_bucket/main.tf
+++ b/examples/logging_target_bucket/main.tf
@@ -24,7 +24,10 @@ module "aws_logs_logs" {
 
   s3_bucket_name = local.log_bucket_name
 
-  default_allow = false
+  default_allow  = false
+  allow_s3       = true
+  s3_logs_prefix = [var.s3_logs_prefix]
+
 
   force_destroy = var.force_destroy
 }

--- a/main.tf
+++ b/main.tf
@@ -255,7 +255,7 @@ data "aws_iam_policy_document" "main" {
         variable = "s3:x-amz-acl"
         values   = ["bucket-owner-full-control"]
       }
-      resources = ["${local.bucket_arn}/${local.config_logs_path}/${statement.value}/Config/*"]
+      resources = local.config_resources
     }
   }
   #
@@ -450,8 +450,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "aws_logs" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = length(var.kms_master_key_id) > 0 ? "aws:kms" : "AES256"
+      kms_master_key_id = length(var.kms_master_key_id) > 0 ? var.kms_master_key_id : null
     }
+    bucket_key_enabled = var.bucket_key_enabled
   }
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,22 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": [
     "dependencies"
   ],
   "packageRules": [
+    {
+      "automerge": true,
+      "description": "Automerge all updates except major versions",
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest",
+        "minor"
+      ]
+    },
     {
       "description": "Tag the waddlers Github Team for major updates",
       "matchUpdateTypes": [
@@ -19,14 +30,18 @@
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
+      "managers": [
+        "terraform",
+        "pre-commit",
+        "github-actions"
+      ],
       "matchUpdateTypes": [
         "minor",
-        "patch",
-        "pin",
-        "digest"
+        "patch"
       ]
     }
   ],
+  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-      "managers": [
+      "matchManagers": [
         "terraform",
         "pre-commit",
         "github-actions"
@@ -41,7 +41,6 @@
       ]
     }
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
This copies `aws_s3_server_side_encryption_configuration` from `terraform-aws-s3-private-bucket` [here](https://github.com/trussworks/terraform-aws-s3-private-bucket/blob/main/main.tf#L264-L274). This adds two supporting variables `kms_master_key_id` and `bucket_key_enabled`. As defined, this contiues to support `AES256` as the default algorithm that the current module supports.

`elb_log_prefixes` is changed from a `string` to a `list(string)` as `resources` in an `iam_policy_document` expects `resources` to be a list. This mirrors `nlb_log_prefixes` and `alb_log_refixes` which are already `list(string)` types.

- **chore: remove unnecessary file**
- **chore: pinning github action**
- **chore: renovate renovate config**
- **chore: ignore lock file**
- **chore: pre-commit autoupdate**
- **feat: pass KMS key to bucket encryption**
