### PR TITLE
fix: elb_logs_prefix should be string not list(string)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -126,8 +126,8 @@ variable "elb_accounts" {
 
 variable "elb_logs_prefix" {
   description = "S3 prefix for ELB logs."
-  default     = ["elb"]
-  type        = list(string)
+  default     = "elb"
+  type        = string
 }
 
 variable "enable_mfa_delete" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = ">= 3.75.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.75.0"
+    }
   }
 }


### PR DESCRIPTION
When attempting a `terraform plan` encountered this error:

```terraform
│ Error: Invalid template interpolation value
│
│   on .terraform/modules/bootstrap.terraform_state_bucket_logs/main.tf line 90, in locals:
│   90:   elb_logs_path = var.elb_logs_prefix == "" ? "AWSLogs" : "${var.elb_logs_prefix}/AWSLogs"
│     ├────────────────
│     │ var.elb_logs_prefix is list of string with 1 element
│
│ Cannot include the given value in a string template: string required.
```

So this sets `elb_logs_prefix` to be a `string` rather than `list(string)`.
