### PR TITLE
chore: remove lifecycle block on bucket policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -395,12 +395,6 @@ resource "aws_s3_bucket" "aws_logs" {
 resource "aws_s3_bucket_policy" "aws_logs" {
   bucket = aws_s3_bucket.aws_logs.id
   policy = data.aws_iam_policy_document.main.json
-  lifecycle {
-    ignore_changes = [
-      # Allows a user to append a custom policy if needed
-      policy
-    ]
-  }
 }
 
 resource "aws_s3_bucket_acl" "aws_logs" {


### PR DESCRIPTION
If a user were to define something like 

```terraform
default_allow = false
```

Then run a `terraform plan` and `terraform apply` for the first time, it would result in all `Effects` in the IAM policy to be `Deny`.

Then if a person were to want to enable s3 logging, they would update like so

```terraform
default_allow = false
allow_s3      = true
```

When running a `terraform plan` it would show `No changes. Your infrastucture matches the configuration.` because the `lifecycle` block ignores changes on `policy`.

Also, should the policy get edited on the console in some manner, a `terraform plan` and `terraform apply` would not revert it back to what's in Terraform, it wouldn't detect the drift at all. Not a desired behavior.
