### PR TITLE
Fix: Provider warning. Update s3_logging_bucket module config to resolve provider warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -436,7 +436,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
     id     = "expire_all_logs"
     status = var.enable_s3_log_bucket_lifecycle_rule ? "Enabled" : "Disabled"
 
-    filter {}
+    filter {
+      prefix = ""
+    }
 
     expiration {
       days = var.s3_log_bucket_retention


### PR DESCRIPTION
## [Resolve Warning: Invalid Attribute Combination](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html)

Changes proposed in this pull request:

- Address deprecation warning for invalid attribute combination in the lifecycle filter
- Update the resource `"aws_s3_bucket_lifecycle_configuration" "aws_logs" {`
-  To use to use explicit `prefix = ""` instead of the empty filter block so:  `filter {prefix = ""}`
- [fix: s3 lifecycle filter warning](https://github.com/goodloemalone/terraform-aws-logs/commit/f4c073ff5136e7a280148ba71338bd9e30bfa5a4)
- Resolves Warning: Invalid Attribute Combination │  This will be an error in a future version of the provider
- `main.tf` line 436: `filter {}`
