### PR TITLE
fix: name attribute is deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   # https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
   # contains a bucket policy and information about when to use that policy.
   is_region_after_082022 = contains(
-  ["ap-south-2", "ap-southeast-4", "ap-southeast-5", "ap-southeast-7", "ca-west-1", "eu-south-2", "eu-central-2", "il-central-1", "me-central-1"], data.aws_region.current.name)
+  ["ap-south-2", "ap-southeast-4", "ap-southeast-5", "ap-southeast-7", "ca-west-1", "eu-south-2", "eu-central-2", "il-central-1", "me-central-1"], data.aws_region.current.region)
 }
 
 # Get the account id of the AWS ALB and ELB service account in a given region for the
@@ -60,7 +60,7 @@ locals {
   cloudwatch_effect = var.default_allow || var.allow_cloudwatch ? "Allow" : "Deny"
 
   # region specific logs service principal
-  cloudwatch_service = "logs.${data.aws_region.current.name}.amazonaws.com"
+  cloudwatch_service = "logs.${data.aws_region.current.region}.amazonaws.com"
 
   cloudwatch_resource = "${local.bucket_arn}/${var.cloudwatch_logs_prefix}/*"
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75.0"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
Similar to what we saw on another module, `data.aws_region.current.name` is deprecated.

```terraform
│ Warning: Deprecated attribute
│
│   on .terraform/modules/logs/main.tf line 6, in locals:
│    6:   ["ap-south-2", "ap-southeast-4", "ap-southeast-5", "ap-southeast-7", "ca-west-1", "eu-south-2", "eu-central-2", "il-central-1", "me-central-1"], data.aws_region.current.name)
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│
│ (and one more similar warning elsewhere)

│ Warning: Deprecated attribute
│
│   on .terraform/modules/logs/main.tf line 63, in locals:
│   63:   cloudwatch_service = "logs.${data.aws_region.current.name}.amazonaws.com"
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
╵
Success! The configuration is valid, but there were some validation warnings as shown above.
```

This will result in a _major_ version bump due to the upgrade in the AWS Provider version requirement.
